### PR TITLE
Add files via upload

### DIFF
--- a/PreprocessDialog.java
+++ b/PreprocessDialog.java
@@ -1,0 +1,705 @@
+/*
+ * Unitex
+ *
+ * Copyright (C) 2001-2021 Université Paris-Est Marne-la-Vallée <unitex@univ-mlv.fr>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
+ *
+ */
+package fr.umlv.unitex.frames;
+
+import java.awt.BorderLayout;
+import java.awt.Dimension;
+import java.awt.GridLayout;
+import java.awt.event.ActionEvent;
+import java.awt.event.KeyEvent;
+import java.io.File;
+import java.util.ArrayList;
+
+import javax.swing.AbstractAction;
+import javax.swing.Action;
+import javax.swing.JButton;
+import javax.swing.JCheckBox;
+import javax.swing.JDialog;
+import javax.swing.JFileChooser;
+import javax.swing.JLabel;
+import javax.swing.JOptionPane;
+import javax.swing.JPanel;
+import javax.swing.JTextField;
+import javax.swing.border.EmptyBorder;
+import javax.swing.border.TitledBorder;
+
+import fr.umlv.unitex.common.project.manager.GlobalProjectManager;
+import fr.umlv.unitex.config.Config;
+import fr.umlv.unitex.config.ConfigManager;
+import fr.umlv.unitex.exceptions.InvalidPolyLexArgumentException;
+import fr.umlv.unitex.listeners.LanguageListener;
+import fr.umlv.unitex.process.Launcher;
+import fr.umlv.unitex.process.commands.DicoCommand;
+import fr.umlv.unitex.process.commands.ErrorMessageCommand;
+import fr.umlv.unitex.process.commands.FlattenCommand;
+import fr.umlv.unitex.process.commands.Fst2TxtCommand;
+import fr.umlv.unitex.process.commands.Grf2Fst2Command;
+import fr.umlv.unitex.process.commands.MkdirCommand;
+import fr.umlv.unitex.process.commands.MultiCommands;
+import fr.umlv.unitex.process.commands.NormalizeCommand;
+import fr.umlv.unitex.process.commands.PolyLexCommand;
+import fr.umlv.unitex.process.commands.SortTxtCommand;
+import fr.umlv.unitex.process.commands.TokenizeCommand;
+import fr.umlv.unitex.process.commands.Txt2TfstCommand;
+import fr.umlv.unitex.process.commands.UnxmlizeCommand;
+import fr.umlv.unitex.text.SntUtil;
+import fr.umlv.unitex.utils.KeyUtil;
+
+/**
+ * This class describes a dialog box that allows the user to parameter the
+ * preprocessing of a text.
+ * 
+ * @author Sébastien Paumier
+ */
+public class PreprocessDialog extends JDialog {
+	private final JCheckBox noSeparatorNormalization = new JCheckBox(
+			"No separator normalization (allows preprocessing graphs to match multi-separators)",
+			false);
+	private final JCheckBox sentenceCheck = new JCheckBox(
+			"Apply graph in MERGE mode:", true);
+	private final JCheckBox replaceCheck = new JCheckBox(
+			"Apply graph in REPLACE mode:", true);
+	private final JTextField sentenceName = new JTextField();
+	private final JTextField replaceName = new JTextField();
+	private final JCheckBox applyDicCheck = new JCheckBox(
+			"Apply All default Dictionaries", true);
+	private final JCheckBox analyseUnknownWordsCheck = new JCheckBox(
+			"Analyse unknown words as free compound words (this option", true);
+	private final JLabel analyseUnknownWordsLabel = new JLabel(
+			"     is available only for Dutch, German, Norwegian & Russian)");
+	private final JCheckBox textFst2Check = new JCheckBox(
+			"Construct Text Automaton");
+	private File originalTextFile;
+	private File sntFile;
+	private final JPanel preprocessingParent;
+	private JPanel preprocessingCurrent;
+	private JPanel preprocessingTaggedText;
+	private JPanel preprocessingUntaggedText;
+	private boolean taggedText = false;
+	private UnxmlizeCommand unxmlizeCmd;
+
+	/**
+	 * Creates and shows a new <code>PreprocessFrame</code>
+	 */
+	PreprocessDialog() {
+		super(UnitexFrame.mainFrame, "Preprocessing & Lexical parsing", true);
+		setContentPane(preprocessingParent = constructPanel());
+		refreshOnLanguageChange();
+		Config.addLanguageListener(new LanguageListener() {
+			@Override
+			public void languageChanged() {
+				refreshOnLanguageChange();
+			}
+		});
+		pack();
+		setResizable(false);
+		setLocationRelativeTo(UnitexFrame.mainFrame);
+		setDefaultCloseOperation(HIDE_ON_CLOSE);
+	}
+
+	void refreshOnLanguageChange() {
+		if (Config.getCurrentLanguage().equals("Dutch")
+				|| Config.getCurrentLanguage().equals("German")
+				|| Config.getCurrentLanguage().equals("Norwegian (Bokmal)")
+				|| Config.getCurrentLanguage().equals("Norwegian (Nynorsk)")
+				|| Config.getCurrentLanguage().equals("Russian")) {
+			analyseUnknownWordsCheck.setSelected(true);
+			analyseUnknownWordsCheck.setEnabled(true);
+			analyseUnknownWordsLabel.setEnabled(true);
+		} else {
+			analyseUnknownWordsCheck.setSelected(false);
+			analyseUnknownWordsCheck.setEnabled(false);
+			analyseUnknownWordsLabel.setEnabled(false);
+		}
+		sentenceName
+				.setText(Config.getCurrentSentenceGraph().getAbsolutePath());
+		replaceName.setText(Config.getCurrentReplaceGraph().getAbsolutePath());
+		applyDicCheck.setSelected(true);
+		textFst2Check.setSelected(false);
+	}
+
+	void setFiles(File originalTextFile, File sntFile, boolean taggedText,
+			UnxmlizeCommand cmd) {
+		this.originalTextFile = originalTextFile;
+		this.sntFile = sntFile;
+		this.taggedText = taggedText;
+		this.unxmlizeCmd = cmd;
+		preprocessingParent.remove(preprocessingCurrent);
+		if (taggedText) {
+			preprocessingCurrent = preprocessingTaggedText;
+		} else {
+			preprocessingCurrent = preprocessingUntaggedText;
+		}
+		preprocessingParent.add(preprocessingCurrent, BorderLayout.NORTH);
+		preprocessingParent.revalidate();
+		repaint();
+	}
+
+	private JPanel constructPanel() {
+		final JPanel panel = new JPanel(new BorderLayout());
+		panel.add(constructProcessingPanel(), BorderLayout.NORTH);
+		panel.add(constructTokenizingPanel(), BorderLayout.CENTER);
+		final JPanel down = new JPanel(new BorderLayout());
+		down.add(constructLexicalParsingPanel(), BorderLayout.WEST);
+		down.add(constructButtonsPanel(), BorderLayout.CENTER);
+		panel.add(down, BorderLayout.SOUTH);
+		KeyUtil.addCloseDialogListener(panel);
+		return panel;
+	}
+
+	private JPanel constructProcessingPanel() {
+		/* Building the panels for both tagged and untagged texts */
+		preprocessingTaggedText = new JPanel(new BorderLayout());
+		preprocessingTaggedText.setBorder(new TitledBorder("Preprocessing"));
+		preprocessingTaggedText
+				.add(new JLabel(
+						"Sentence and Replace graphs should not be applied on tagged texts."));
+		preprocessingUntaggedText = new JPanel(new GridLayout(3, 1));
+		preprocessingUntaggedText.setBorder(new TitledBorder("Preprocessing"));
+		sentenceCheck.setMnemonic(KeyEvent.VK_M);
+		replaceCheck.setMnemonic(KeyEvent.VK_R);
+		preprocessingUntaggedText.add(noSeparatorNormalization);
+		preprocessingUntaggedText.add(constructGenericPanelSentence(sentenceCheck,
+				sentenceName, true));
+		preprocessingUntaggedText.add(constructGenericPanel(replaceCheck,
+				replaceName, true));
+		return preprocessingCurrent = preprocessingUntaggedText;
+	}
+
+	
+	private JPanel constructGenericPanelSentence(final JCheckBox checkBoxSentence,
+			final JTextField textFieldSentence, final boolean mnemonicTokenSentence) {
+		final JPanel panel = new JPanel(new BorderLayout());
+		checkBoxSentence.setPreferredSize(new Dimension(190, checkBoxSentence
+				.getPreferredSize().height));
+		panel.add(checkBoxSentence, BorderLayout.WEST);
+		textFieldSentence.setPreferredSize(new Dimension(150, textFieldSentence
+				.getPreferredSize().height));
+		panel.add(textFieldSentence, BorderLayout.CENTER);
+		final Action setActionSentence = new AbstractAction("Set...") {
+			@Override
+			public void actionPerformed(ActionEvent e) {
+				final JFileChooser chooser = Config.getSentenceDialogBox();
+				final int returnVal = chooser.showOpenDialog(null);
+				if (returnVal != JFileChooser.APPROVE_OPTION) {
+					// we return if the user has clicked on cancel
+					return;
+				}
+				textFieldSentence.setText(chooser.getSelectedFile().getAbsolutePath());
+			}
+		};
+		final JButton setSentence = new JButton(setActionSentence);
+		if (mnemonicTokenSentence) {
+			setSentence.setMnemonic(KeyEvent.VK_E);
+		} else {
+			setSentence.setMnemonic(KeyEvent.VK_S);
+		}
+		panel.add(setSentence, BorderLayout.EAST);
+		return panel;
+	}
+	
+	private JPanel constructGenericPanel(final JCheckBox checkBox,
+			final JTextField textField, final boolean mnemonicToken) {
+		final JPanel panel = new JPanel(new BorderLayout());
+		checkBox.setPreferredSize(new Dimension(190, checkBox
+				.getPreferredSize().height));
+		panel.add(checkBox, BorderLayout.WEST);
+		textField.setPreferredSize(new Dimension(150, textField
+				.getPreferredSize().height));
+		panel.add(textField, BorderLayout.CENTER);
+		final Action setAction = new AbstractAction("Set...") {
+			@Override
+			public void actionPerformed(ActionEvent e) {
+				final JFileChooser chooser = Config.getReplaceDialogBox();
+				final int returnVal = chooser.showOpenDialog(null);
+				if (returnVal != JFileChooser.APPROVE_OPTION) {
+					// we return if the user has clicked on cancel
+					return;
+				}
+				textField.setText(chooser.getSelectedFile().getAbsolutePath());
+			}
+		};
+		final JButton setReplace = new JButton(setAction);
+		if (mnemonicToken) {
+			setReplace.setMnemonic(KeyEvent.VK_E);
+		} else {
+			setReplace.setMnemonic(KeyEvent.VK_S);
+		}
+		panel.add(setReplace, BorderLayout.EAST);
+		return panel;
+	}
+		
+
+	private JPanel constructTokenizingPanel() {
+		final JPanel tokenizingPanel = new JPanel(new GridLayout(2, 1));
+		tokenizingPanel.setBorder(new TitledBorder("Tokenizing"));
+		tokenizingPanel
+				.add(new JLabel(
+						"The text is automatically tokenized. This operation is language-dependant,"));
+		tokenizingPanel
+				.add(new JLabel(
+						"so that Unitex can handle languages with special spacing rules."));
+		return tokenizingPanel;
+	}
+
+	private JPanel constructLexicalParsingPanel() {
+		final JPanel lexicalParsing = new JPanel(new GridLayout(4, 1));
+		lexicalParsing.setBorder(new TitledBorder("Lexical Parsing"));
+		applyDicCheck.setMnemonic(KeyEvent.VK_D);
+		lexicalParsing.add(applyDicCheck);
+		analyseUnknownWordsCheck.setMnemonic(KeyEvent.VK_W);
+		lexicalParsing.add(analyseUnknownWordsCheck);
+		lexicalParsing.add(analyseUnknownWordsLabel);
+		textFst2Check.setMnemonic(KeyEvent.VK_A);
+		lexicalParsing.add(textFst2Check);
+		return lexicalParsing;
+	}
+
+	private JPanel constructButtonsPanel() {
+		final JPanel buttons = new JPanel(new GridLayout(3, 1));
+		buttons.setBorder(new EmptyBorder(8, 8, 2, 2));
+		final Action goAction = new AbstractAction("GO!") {
+			@Override
+			public void actionPerformed(ActionEvent e) {
+				setVisible(false);
+				preprocess();
+			}
+		};
+		final JButton goButton = new JButton(goAction);
+		goButton.setMnemonic(KeyEvent.VK_G);
+		final Action cancelButIndexAction = new AbstractAction(
+				"Cancel but tokenize text") {
+			@Override
+			public void actionPerformed(ActionEvent e) {
+				// if the user has clicked on cancel but tokenize, we must
+				// tokenize anyway
+				setVisible(false);
+				justTokenize();
+			}
+		};
+		final JButton cancelButIndex = new JButton(cancelButIndexAction);
+		cancelButIndex.setMnemonic(KeyEvent.VK_T);
+		final Action cancelAction = new AbstractAction("Cancel and close text") {
+			@Override
+			public void actionPerformed(ActionEvent e) {
+				// if the user has clicked on cancel, we do nothing
+				setVisible(false);
+				GlobalProjectManager.search(null).getFrameManagerAs(InternalFrameManager.class)
+						.closeTextFrame();
+			}
+		};
+		final JButton cancel = new JButton(cancelAction);
+		cancel.setMnemonic(KeyEvent.VK_L);
+		buttons.add(goButton);
+		buttons.add(cancelButIndex);
+		buttons.add(cancel);
+		return buttons;
+	}
+
+	private MultiCommands normalizingText(final MultiCommands commands,
+			File inputOffsets, File outputOffsets) {
+		NormalizeCommand normalizeCmd = new NormalizeCommand()
+				.textWithDefaultNormalization(originalTextFile);
+		if (!taggedText && noSeparatorNormalization.isSelected()) {
+			normalizeCmd = normalizeCmd.noSeparatorNormalization();
+		}
+		if (inputOffsets != null) {
+			normalizeCmd = normalizeCmd.inputOffsets(inputOffsets);
+		}
+		if (outputOffsets != null) {
+			normalizeCmd = normalizeCmd.outputOffsets(outputOffsets);
+		}
+		commands.addCommand(normalizeCmd);
+		return commands;
+	}
+
+	void justTokenize() {
+		MultiCommands commands = new MultiCommands();
+		final File dir = Config.getCurrentSntDir();
+		if (!dir.exists()) {
+			// if the directory toto_snt does not exist, we
+			// create it
+			final MkdirCommand mkdir = new MkdirCommand().name(dir);
+			commands.addCommand(mkdir);
+		}
+		final File sntDir = Config.getCurrentSntDir();
+		File nextOutputOffsets = null;
+		File lastOutputOffsets = null;
+		if (unxmlizeCmd != null) {
+			commands.addCommand(unxmlizeCmd);
+			lastOutputOffsets = new File(sntDir, "unxmlize.out.offsets");
+			nextOutputOffsets = new File(sntDir, "normalize.out.offsets");
+		}
+                else {
+                    nextOutputOffsets = new File(sntDir, "normalize.out.offsets");
+                }
+		commands = normalizingText(commands, lastOutputOffsets,
+				nextOutputOffsets);
+		lastOutputOffsets = nextOutputOffsets;
+		nextOutputOffsets = new File(sntDir, "tokenize.out.offsets");
+		// TOKENIZING...
+		TokenizeCommand tokenizeCmd = new TokenizeCommand().text(
+				Config.getCurrentSnt()).alphabet(
+				ConfigManager.getManager().getAlphabet(null));
+		if (Config.getCurrentLanguage().equals("Thai")
+				|| Config.getCurrentLanguage().equals("Chinese")) {
+			tokenizeCmd = tokenizeCmd.tokenizeCharByChar();
+		}
+		if (lastOutputOffsets != null) {
+			tokenizeCmd = tokenizeCmd.inputOffsets(lastOutputOffsets);
+		}
+		commands.addCommand(tokenizeCmd);
+		GlobalProjectManager.search(null).getFrameManagerAs(InternalFrameManager.class)
+				.closeTextFrame();
+		SntUtil.cleanSntDir(Config.getCurrentSntDir());
+		Launcher.exec(commands, true,
+				new AfterPreprocessDo(sntFile, taggedText));
+	}
+
+	private MultiCommands applyDefaultDictionaries(final MultiCommands commands) {
+		DicoCommand dicoCmd;
+		dicoCmd = new DicoCommand()
+				.snt(Config.getCurrentSnt())
+				.alphabet(ConfigManager.getManager().getAlphabet(null))
+				.morphologicalDic(
+						ConfigManager.getManager().morphologicalDictionaries(
+								null));
+		if (ConfigManager.getManager().isKorean(null)) {
+			dicoCmd = dicoCmd.korean();
+		}
+		if (ConfigManager.getManager().isArabic(null)) {
+			dicoCmd = dicoCmd.arabic(new File(Config
+					.getUserCurrentLanguageDir(), "arabic_typo_rules.txt"));
+		}
+		if (ConfigManager.getManager().isSemiticLanguage(null)) {
+			dicoCmd = dicoCmd.semitic();
+		}
+		final ArrayList<File> param = Config.getDefaultDicList();
+		if (param != null && param.size() > 0) {
+			dicoCmd = dicoCmd.dictionaryList(param);
+			commands.addCommand(dicoCmd);
+		} else {
+			dicoCmd = null;
+		}
+		// ANALYSING UNKNOWN WORDS
+		final String lang = Config.getCurrentLanguage();
+		File dic = new File(Config.getUnitexCurrentLanguageDir(), "Dela");
+		if (lang.equals("German"))
+			dic = new File(dic, "dela.bin");
+		else if (lang.equals("Norwegian (Bokmal)"))
+			dic = new File(dic, "Dela-sample.bin");
+		else if (lang.equals("Norwegian (Nynorsk)"))
+			dic = new File(dic, "Dela-sample.bin");
+		else if (lang.equals("Russian"))
+			dic = new File(dic, "CISLEXru_igrok.bin");
+		if (analyseUnknownWordsCheck.isSelected()) {
+			PolyLexCommand polyLexCmd;
+			try {
+				polyLexCmd = new PolyLexCommand()
+						.language(lang)
+						.alphabet(ConfigManager.getManager().getAlphabet(null))
+						.bin(dic)
+						.wordList(new File(Config.getCurrentSntDir(), "err"))
+						.output(new File(Config.getCurrentSntDir(), "dlf"))
+						.info(new File(Config.getCurrentSntDir(), "decomp.txt"));
+				commands.addCommand(polyLexCmd);
+			} catch (final InvalidPolyLexArgumentException e) {
+				e.printStackTrace();
+			}
+		}
+		// SORTING TEXT DICTIONARIES
+		final File alph = new File(Config.getUserCurrentLanguageDir(),
+				"Alphabet_sort.txt");
+		if (dicoCmd != null) {
+			// sorting DLF
+			SortTxtCommand sortCmd = new SortTxtCommand().file(
+					new File(Config.getCurrentSntDir(), "dlf"))
+					.saveNumberOfLines(
+							new File(Config.getCurrentSntDir(), "dlf.n"));
+			if (Config.getCurrentLanguage().equals("Thai")) {
+				sortCmd = sortCmd.thai(true);
+			} else {
+				sortCmd = sortCmd.sortAlphabet(alph);
+			}
+			commands.addCommand(sortCmd);
+			// sorting DLC
+			SortTxtCommand sortCmd2 = new SortTxtCommand().file(
+					new File(Config.getCurrentSntDir(), "dlc"))
+					.saveNumberOfLines(
+							new File(Config.getCurrentSntDir(), "dlc.n"));
+			if (Config.getCurrentLanguage().equals("Thai")) {
+				sortCmd2 = sortCmd2.thai(true);
+			} else {
+				sortCmd2 = sortCmd2.sortAlphabet(alph);
+			}
+			commands.addCommand(sortCmd2);
+			// sorting ERR
+			SortTxtCommand sortCmd3 = new SortTxtCommand().file(
+					new File(Config.getCurrentSntDir(), "err"))
+					.saveNumberOfLines(
+							new File(Config.getCurrentSntDir(), "err.n"));
+			if (Config.getCurrentLanguage().equals("Thai")) {
+				sortCmd3 = sortCmd3.thai(true);
+			} else {
+				sortCmd3 = sortCmd3.sortAlphabet(alph);
+			}
+			commands.addCommand(sortCmd3);
+			// sorting TAGS_ERR
+			SortTxtCommand sortCmd4 = new SortTxtCommand().file(
+					new File(Config.getCurrentSntDir(), "tags_err"))
+					.saveNumberOfLines(
+							new File(Config.getCurrentSntDir(), "tags_err.n"));
+			if (Config.getCurrentLanguage().equals("Thai")) {
+				sortCmd4 = sortCmd4.thai(true);
+			} else {
+				sortCmd4 = sortCmd4.sortAlphabet(alph);
+			}
+			commands.addCommand(sortCmd4);
+		}
+		return commands;
+	}
+
+	private void showMsgDialog() {
+		// if the extension is nor GRF neither
+		// FST2
+		JOptionPane.showMessageDialog(null, "Invalid graph name extension !",
+				"Error", JOptionPane.ERROR_MESSAGE);
+	}
+
+	private MultiCommands constructTextAutomaton(final MultiCommands commands) {
+		File norm = Config.getCurrentNormGraph();
+		if (!norm.exists()) {
+			commands.addCommand(new ErrorMessageCommand(
+					"*** WARNING: normalization graph was not found ***\n"));
+			norm = null;
+		} else {
+			final String grfName = norm.getAbsolutePath();
+			if (grfName.substring(grfName.length() - 3, grfName.length())
+					.equalsIgnoreCase("grf")) {
+				// we must compile the grf
+				final File grf = new File(grfName);
+				final Grf2Fst2Command grfCmd = new Grf2Fst2Command().grf(grf)
+						.enableLoopAndRecursionDetection(true)
+						.tokenizationMode(null, grf).emitEmptyGraphWarning()
+						.displayGraphNames().repositories();
+				commands.addCommand(grfCmd);
+				String fst2Name = grfName.substring(0, grfName.length() - 3);
+				fst2Name = fst2Name + "fst2";
+				norm = new File(fst2Name);
+			} else {
+				if (!(grfName.substring(grfName.length() - 4, grfName.length())
+						.equalsIgnoreCase("fst2"))) {
+					showMsgDialog();
+				}
+			}
+		}
+		Txt2TfstCommand txtCmd = new Txt2TfstCommand()
+				.text(Config.getCurrentSnt())
+				.alphabet(ConfigManager.getManager().getAlphabet(null))
+				.clean(true);
+		if (ConfigManager.getManager().isKorean(null)) {
+			txtCmd = txtCmd.korean();
+		}
+		if (norm != null) {
+			txtCmd = txtCmd.fst2(norm);
+		}
+		commands.addCommand(txtCmd);
+		return commands;
+	}
+
+	private MultiCommands replaceGraph(final MultiCommands commands,
+			File inputOffsets, File outputOffsets) {
+		final File f = new File(replaceName.getText());
+		if (!f.exists()) {
+			commands.addCommand(new ErrorMessageCommand(
+					"*** WARNING: Replace step skipped because the graph was not found ***\n"));
+		} else {
+			final String grfName = replaceName.getText();
+			File fst2;
+			if (grfName.substring(grfName.length() - 3, grfName.length())
+					.equalsIgnoreCase("grf")) {
+				// we must compile the grf
+				final File grf = new File(grfName);
+				final Grf2Fst2Command grfCmd = new Grf2Fst2Command().grf(grf)
+						.enableLoopAndRecursionDetection(true)
+						.tokenizationMode(null, grf).repositories()
+						.emitEmptyGraphWarning().displayGraphNames();
+				commands.addCommand(grfCmd);
+				String fst2Name = grfName.substring(0, grfName.length() - 3);
+				fst2Name = fst2Name + "fst2";
+				fst2 = new File(fst2Name);
+			} else {
+				if (!(grfName.substring(grfName.length() - 4, grfName.length())
+						.equalsIgnoreCase("fst2"))) {
+					showMsgDialog();
+				}
+				fst2 = new File(grfName);
+			}
+			Fst2TxtCommand cmd = new Fst2TxtCommand()
+					.text(Config.getCurrentSnt()).fst2(fst2)
+					.alphabet(ConfigManager.getManager().getAlphabet(null))
+					.mode(false);
+			cmd = cmd.charByChar(ConfigManager.getManager()
+					.isCharByCharLanguage(null));
+			cmd = cmd.morphologicalUseOfSpace(ConfigManager.getManager()
+					.isMorphologicalUseOfSpaceAllowed(null));
+			if (inputOffsets != null) {
+				cmd = cmd.inputOffsets(inputOffsets);
+			}
+			if (outputOffsets != null) {
+				cmd = cmd.outputOffsets(outputOffsets);
+			}
+			commands.addCommand(cmd);
+		}
+		return commands;
+	}
+
+	private MultiCommands sentenceGraph(final MultiCommands commands,
+			File inputOffsets, File outputOffsets) {
+		final File sentence = new File(sentenceName.getText());
+		if (!sentence.exists()) {
+			commands.addCommand(new ErrorMessageCommand(
+					"*** WARNING: sentence delimitation skipped because the graph was not found ***\n"));
+		} else {
+			final String grfName = sentenceName.getText();
+			File fst2;
+			if (grfName.substring(grfName.length() - 3, grfName.length())
+					.equalsIgnoreCase("grf")) {
+				// we must compile the grf
+				final File grf = new File(grfName);
+				final Grf2Fst2Command grfCmd = new Grf2Fst2Command().grf(grf)
+						.enableLoopAndRecursionDetection(true)
+						.tokenizationMode(null, grf).repositories()
+						.emitEmptyGraphWarning().displayGraphNames();
+				commands.addCommand(grfCmd);
+				String fst2Name = grfName.substring(0, grfName.length() - 3);
+				fst2Name = fst2Name + "fst2";
+				fst2 = new File(fst2Name);
+				// and flatten it for better performance
+				// (Fst2Txt is slow with complex graphs)
+				final FlattenCommand flattenCmd = new FlattenCommand()
+						.fst2(fst2).resultType(false).depth(5);
+				commands.addCommand(flattenCmd);
+			} else {
+				if (!(grfName.substring(grfName.length() - 4, grfName.length())
+						.equalsIgnoreCase("fst2"))) {
+					showMsgDialog();
+				}
+				fst2 = new File(grfName);
+			}
+			Fst2TxtCommand cmd = new Fst2TxtCommand()
+					.text(Config.getCurrentSnt()).fst2(fst2)
+					.alphabet(ConfigManager.getManager().getAlphabet(null))
+					.mode(true);
+			cmd = cmd.charByChar(ConfigManager.getManager()
+					.isCharByCharLanguage(null));
+			cmd = cmd.morphologicalUseOfSpace(ConfigManager.getManager()
+					.isMorphologicalUseOfSpaceAllowed(null));
+			if (inputOffsets != null) {
+				cmd = cmd.inputOffsets(inputOffsets);
+			}
+			if (outputOffsets != null) {
+				cmd = cmd.outputOffsets(outputOffsets);
+			}
+			commands.addCommand(cmd);
+		}
+		return commands;
+	}
+
+	private MultiCommands createSndDir(final MultiCommands commands) {
+		final File dir = Config.getCurrentSntDir();
+		if (!dir.exists()) {
+			final MkdirCommand mkdir = new MkdirCommand().name(dir);
+			commands.addCommand(mkdir);
+		}
+		return commands;
+	}
+
+	private MultiCommands tokenization(final MultiCommands commands,
+			File inputOffsets, File outputOffsets) {
+		TokenizeCommand tokenizeCmd = new TokenizeCommand().text(
+				Config.getCurrentSnt()).alphabet(
+				ConfigManager.getManager().getAlphabet(null));
+		if (ConfigManager.getManager().isCharByCharLanguage(null)) {
+			tokenizeCmd = tokenizeCmd.tokenizeCharByChar();
+		}
+		if (inputOffsets != null) {
+			tokenizeCmd = tokenizeCmd.inputOffsets(inputOffsets);
+		}
+		if (outputOffsets != null) {
+			tokenizeCmd = tokenizeCmd.outputOffsets(outputOffsets);
+		}
+		commands.addCommand(tokenizeCmd);
+		return commands;
+	}
+
+	void preprocess() {
+		final File sntDir = Config.getCurrentSntDir();
+		// build & execute a command chain
+		MultiCommands commands = new MultiCommands();
+		commands = createSndDir(commands);
+		final boolean offsets = (unxmlizeCmd != null);
+		File nextOutputOffsets = null;
+		File lastOutputOffsets = null;
+		if (unxmlizeCmd != null) {
+			commands.addCommand(unxmlizeCmd);
+			lastOutputOffsets = new File(sntDir, "unxmlize.out.offsets");
+			nextOutputOffsets = new File(sntDir, "normalize.out.offsets");
+		}
+                else {
+                    nextOutputOffsets = new File(sntDir, "normalize.out.offsets");
+                }
+		commands = normalizingText(commands, lastOutputOffsets,
+				nextOutputOffsets);
+		lastOutputOffsets = nextOutputOffsets;
+		if (sentenceCheck.isSelected()) {
+			if (offsets) {
+				nextOutputOffsets = new File(sntDir, "sentence.out.offsets");
+			}
+			commands = sentenceGraph(commands, lastOutputOffsets,
+					nextOutputOffsets);
+		}
+		lastOutputOffsets = nextOutputOffsets;
+		if (replaceCheck.isSelected()) {
+			if (offsets) {
+				nextOutputOffsets = new File(sntDir, "replace.out.offsets");
+			}
+			commands = replaceGraph(commands, lastOutputOffsets,
+					nextOutputOffsets);
+		}
+		lastOutputOffsets = nextOutputOffsets;
+		//if (offsets) {
+		nextOutputOffsets = new File(sntDir, "tokenize.out.offsets");  
+		//}
+		commands = tokenization(commands, lastOutputOffsets, nextOutputOffsets);
+		if (applyDicCheck.isSelected()) {
+			commands = applyDefaultDictionaries(commands);
+		}
+		if (textFst2Check.isSelected()) {
+			commands = constructTextAutomaton(commands);
+		}
+		GlobalProjectManager.search(null).getFrameManagerAs(InternalFrameManager.class)
+				.closeTextFrame();
+		SntUtil.cleanSntDir(sntDir);
+		Launcher.exec(commands, true,
+				new AfterPreprocessDo(sntFile, taggedText));
+	}
+}

--- a/XAlignConfigFrame.java
+++ b/XAlignConfigFrame.java
@@ -1,0 +1,329 @@
+/*
+ * Unitex
+ *
+ * Copyright (C) 2001-2021 Université Paris-Est Marne-la-Vallée <unitex@univ-mlv.fr>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
+ *
+ */
+package fr.umlv.unitex.frames;
+
+import java.awt.BorderLayout;
+import java.awt.Component;
+import java.awt.Dimension;
+import java.awt.GridLayout;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+import java.io.File;
+
+import javax.swing.BorderFactory;
+import javax.swing.Box;
+import javax.swing.BoxLayout;
+import javax.swing.JButton;
+import javax.swing.JFileChooser;
+import javax.swing.JInternalFrame;
+import javax.swing.JOptionPane;
+import javax.swing.JPanel;
+import javax.swing.JTextField;
+
+import fr.umlv.unitex.common.project.manager.GlobalProjectManager;
+import fr.umlv.unitex.config.Config;
+import fr.umlv.unitex.files.FileUtil;
+import fr.umlv.unitex.files.PersonalFileFilter;
+import fr.umlv.unitex.process.Launcher;
+import fr.umlv.unitex.process.ToDo;
+import fr.umlv.unitex.process.commands.MultiCommands;
+import fr.umlv.unitex.process.commands.NormalizeCommand;
+import fr.umlv.unitex.process.commands.XMLizerCommand;
+import fr.umlv.unitex.utils.KeyUtil;
+
+/**
+ * This class describes the XAlign parameter frame.
+ * 
+ * @author Sébastien Paumier
+ */
+public class XAlignConfigFrame extends JInternalFrame {
+	XAlignConfigFrame() {
+		super("XAlign", false, true);
+		setContentPane(constructPanel());
+		pack();
+		setLocation(250, 200);
+		setDefaultCloseOperation(HIDE_ON_CLOSE);
+	}
+
+	private JFileChooser textChooser() {
+		final JFileChooser chooser = new JFileChooser();
+		chooser.addChoosableFileFilter(new PersonalFileFilter("xml", "TEI text"));
+		chooser.addChoosableFileFilter(new PersonalFileFilter("txt",
+				"Raw text file"));
+		chooser.setDialogType(JFileChooser.OPEN_DIALOG);
+		chooser.setCurrentDirectory(Config.getUserDir());
+		chooser.setMultiSelectionEnabled(false);
+		return chooser;
+	}
+
+	public static JFileChooser alignmentChooser() {
+		final JFileChooser chooser = new JFileChooser();
+		chooser.addChoosableFileFilter(new PersonalFileFilter("xml",
+				"XAlign alignment file"));
+		chooser.setDialogType(JFileChooser.OPEN_DIALOG);
+		chooser.setCurrentDirectory(new File(Config.getUserDir(), "XAlign"));
+		chooser.setMultiSelectionEnabled(false);
+		return chooser;
+	}
+	
+	
+	JFileChooser saveXMLChooser() {
+		final JFileChooser chooser = textChooser();
+		chooser.addChoosableFileFilter(new PersonalFileFilter("xml", "TEI text"));
+		chooser.setDialogType(JFileChooser.SAVE_DIALOG);
+		chooser.setCurrentDirectory(Config.getUserDir());
+		chooser.setMultiSelectionEnabled(false);
+		return chooser;
+	}
+
+	private final JTextField text1 = new JTextField();
+	private final JTextField text2 = new JTextField();
+	private final JTextField alignment = new JTextField();
+
+	private JPanel constructPanel() {
+		final JPanel panel = new JPanel(new GridLayout(4, 1));
+		panel.add(buildPanel("Source text", text1, textChooser()));
+		panel.add(buildPanel("Target text", text2, textChooser()));
+		panel.add(buildPanel("Alignment file (optional)", alignment,
+				alignmentChooser()));
+		panel.add(buildButtonPanel());
+		return panel;
+	}
+
+	private Component buildButtonPanel() {
+		final JPanel p = new JPanel(null);
+		p.setLayout(new BoxLayout(p, BoxLayout.X_AXIS));
+		final JButton ok = new JButton("OK");
+		ok.addActionListener(new ActionListener() {
+			@Override
+			public void actionPerformed(ActionEvent e) {
+				loadFiles();
+			}
+		});
+		final JButton cancel = new JButton("Cancel");
+		cancel.addActionListener(new ActionListener() {
+			@Override
+			public void actionPerformed(ActionEvent e) {
+				setVisible(false);
+			}
+		});
+		p.add(Box.createHorizontalGlue());
+		p.add(ok);
+		p.add(Box.createHorizontalStrut(3));
+		p.add(cancel);
+		p.add(Box.createHorizontalStrut(5));
+		KeyUtil.addEscListener(p, cancel);
+		return p;
+	}
+
+	void loadFiles() {
+		final MultiCommands commands = new MultiCommands();
+		String s = Config.getUserDir().getAbsolutePath();
+		//String s = text1.folder_Location.getText();
+		if ("".equals(s)) {
+			JOptionPane.showMessageDialog(null, "You must set the source text",
+					"Error", JOptionPane.ERROR_MESSAGE);
+			return;
+		}
+		final File source = new File(s);
+		final File xmlSourceFile;
+		if (!source.exists()) {
+			JOptionPane.showMessageDialog(null, "Source text not found!",
+					"Error", JOptionPane.ERROR_MESSAGE);
+			return;
+		}
+		if (source.getAbsolutePath().endsWith("txt")) {
+			/* If the user wants to open a raw text file */
+			JOptionPane
+					.showMessageDialog(
+							null,
+							"Your source file is a .txt one. Please select the\n"
+									+ "destination file to be used by XAlign (TEI format).",
+							"", JOptionPane.INFORMATION_MESSAGE);
+			final JFileChooser chooser = saveXMLChooser();
+			final int returnVal = chooser.showSaveDialog(null);
+			if (returnVal != JFileChooser.APPROVE_OPTION) {
+				// we return if the user has clicked on CANCEL
+				return;
+			}
+			File xmlSource = chooser.getSelectedFile();
+			if (!xmlSource.getAbsolutePath().endsWith(".xml")) {
+				xmlSource = new File(xmlSource.getAbsolutePath() + ".xml");
+			}
+			xmlSourceFile = xmlSource;
+			File alphabet = XAlignFrame.tryToFindAlphabet(source);
+			if (alphabet == null) {
+				alphabet = XAlignFrame.tryToFindAlphabet(xmlSource);
+			}
+			if (alphabet == null) {
+				JOptionPane
+						.showMessageDialog(
+								null,
+								"Cannot determine the alphabet file to use\n"
+										+ "in order to process your text. You should place\n"
+										+ "your file within a language directory (e.g. English).",
+								"Error", JOptionPane.ERROR_MESSAGE);
+				return;
+			}
+			final File sentence = new File(new File(
+					Config.getXAlignDirectory(), "Sentence"),
+					"SentenceXAlign.fst2");
+			if (!sentence.exists()) {
+				JOptionPane.showMessageDialog(null,
+						"Cannot find the XAlign sentence graph.\n", "Error",
+						JOptionPane.ERROR_MESSAGE);
+				return;
+			}
+			final NormalizeCommand norm = new NormalizeCommand()
+					.textWithDefaultNormalization(source);
+			commands.addCommand(norm);
+			final String snt = FileUtil.getFileNameWithoutExtension(source)
+					+ ".snt";
+			final XMLizerCommand cmd = new XMLizerCommand().output(xmlSource)
+					.alphabet(alphabet).sentence(sentence).input(new File(snt));
+			commands.addCommand(cmd);
+		} else {
+			xmlSourceFile = source;
+		}
+		s = Config.getUserDir().getAbsolutePath();
+		//s = text2.getText();
+		if ("".equals(s)) {
+			JOptionPane.showMessageDialog(null, "You must set the target text",
+					"Error", JOptionPane.ERROR_MESSAGE);
+			return;
+		}
+		final File dest = new File(s);
+		final File xmlTargetFile;
+		if (!dest.exists()) {
+			JOptionPane.showMessageDialog(null, "Target text not found!",
+					"Error", JOptionPane.ERROR_MESSAGE);
+			return;
+		}
+		if (dest.getAbsolutePath().endsWith("txt")) {
+			/* If the user wants to open a raw text file */
+			JOptionPane
+					.showMessageDialog(
+							null,
+							"Your target file is a .txt one. Please select the\n"
+									+ "destination file to be used by XAlign (TEI format).",
+							"", JOptionPane.INFORMATION_MESSAGE);
+			final JFileChooser chooser = saveXMLChooser();
+			final int returnVal = chooser.showSaveDialog(null);
+			if (returnVal != JFileChooser.APPROVE_OPTION) {
+				// we return if the user has clicked on CANCEL
+				return;
+			}
+			File xmlTarget = chooser.getSelectedFile();
+			xmlTargetFile = xmlTarget;
+			if (!xmlTarget.getAbsolutePath().endsWith(".xml")) {
+				xmlTarget = new File(xmlTarget.getAbsolutePath() + ".xml");
+			}
+			File alphabet = XAlignFrame.tryToFindAlphabet(dest);
+			if (alphabet == null) {
+				alphabet = XAlignFrame.tryToFindAlphabet(xmlTarget);
+			}
+			if (alphabet == null) {
+				JOptionPane
+						.showMessageDialog(
+								null,
+								"Cannot determine the alphabet file to use\n"
+										+ "in order to process your text. You should place\n"
+										+ "your file within a language directory (e.g. English).",
+								"Error", JOptionPane.ERROR_MESSAGE);
+				return;
+			}
+			final File sentence = new File(new File(
+					Config.getXAlignDirectory(), "Sentence"),
+					"SentenceXAlign.fst2");
+			if (!sentence.exists()) {
+				JOptionPane.showMessageDialog(null,
+						"Cannot find the XAlign sentence graph.\n", "Error",
+						JOptionPane.ERROR_MESSAGE);
+				return;
+			}
+			final NormalizeCommand norm = new NormalizeCommand()
+					.textWithDefaultNormalization(dest);
+			commands.addCommand(norm);
+			final String snt = FileUtil.getFileNameWithoutExtension(dest)
+					+ ".snt";
+			final XMLizerCommand cmd = new XMLizerCommand().output(xmlTarget)
+					.alphabet(alphabet).sentence(sentence).input(new File(snt));
+			commands.addCommand(cmd);
+		} else {
+			xmlTargetFile = dest;
+		}
+		File alignmentFile = null;
+		s = Config.getUserDir().getAbsolutePath();
+		//s = alignment.getText();
+		if (!"".equals(s)) {
+			alignmentFile = new File(s);
+			if (!alignmentFile.exists()) {
+				JOptionPane.showMessageDialog(null,
+						"Alignment file not found!", "Error",
+						JOptionPane.ERROR_MESSAGE);
+				return;
+			}
+		}
+		final File alignmentFile2 = alignmentFile;
+		/* We close the parameter frame */
+		setVisible(false);
+		GlobalProjectManager.search(null)
+				.getFrameManagerAs(UnitexInternalFrameManager.class).closeXAlignFrame();
+		final ToDo toDo = new ToDo() {
+			@Override
+			public void toDo(boolean success) {
+				GlobalProjectManager.search(null)
+						.getFrameManagerAs(UnitexInternalFrameManager.class)
+						.newXAlignFrame(xmlSourceFile, xmlTargetFile, alignmentFile2);
+			}
+		};
+		/* And we launch the XMLizer commands, if any */
+		if (commands.numberOfCommands() != 0) {
+			Launcher.exec(commands, true, toDo, true);
+		} else {
+			toDo.toDo(true);
+		}
+	}
+
+	private JPanel buildPanel(String s, final JTextField text,
+			final JFileChooser chooser) {
+		final JPanel p = new JPanel(new BorderLayout());
+		p.setBorder(BorderFactory.createTitledBorder(s));
+		text.setPreferredSize(new Dimension(300, 25));
+		p.add(text, BorderLayout.CENTER);
+		final JButton button = new JButton("set");
+		button.addActionListener(new ActionListener() {
+			@Override
+			public void actionPerformed(ActionEvent e) {
+				final int returnVal = chooser.showOpenDialog(null);
+				if (returnVal != JFileChooser.APPROVE_OPTION) {
+					// we return if the user has clicked on CANCEL
+					return;
+				}
+				text.setText(chooser.getSelectedFile().getAbsolutePath());
+				File folder_Location = chooser.getSelectedFile();
+				Config.setUserDir(folder_Location);
+			}
+		});
+		p.add(button, BorderLayout.EAST);
+		return p;
+	}
+}

--- a/config/Config.java
+++ b/config/Config.java
@@ -1,0 +1,1646 @@
+/*
+ * Unitex
+ *
+ * Copyright (C) 2001-2021 Université Paris-Est Marne-la-Vallée <unitex@univ-mlv.fr>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
+ *
+ */
+package fr.umlv.unitex.config;
+
+import java.awt.GridLayout;
+import java.awt.BorderLayout;
+import java.awt.Dimension;
+import java.awt.Toolkit;
+
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.FileFilter;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.FileReader;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.io.InputStreamReader;
+
+import java.lang.Process;
+import java.lang.ProcessBuilder;
+
+import java.util.ArrayList;
+import java.util.Random;
+import java.util.Scanner;
+import java.util.Set;
+import java.util.TreeSet;
+
+import javax.swing.JComboBox;
+import javax.swing.JFileChooser;
+import javax.swing.JFrame;
+import javax.swing.JLabel;
+import javax.swing.JOptionPane;
+import javax.swing.JPanel;
+import javax.swing.JDialog;
+import javax.swing.JProgressBar;
+import javax.swing.SwingWorker;
+
+import fr.umlv.unitex.Unitex;
+import fr.umlv.unitex.files.FileUtil;
+import fr.umlv.unitex.files.PersonalFileFilter;
+import fr.umlv.unitex.listeners.LanguageListener;
+import fr.umlv.unitex.svn.SvnMonitor;
+
+import fr.umlv.unitex.process.commands.CommandBuilder;
+import fr.umlv.unitex.process.commands.VersionInfoCommand;
+
+/**
+ * This class contains general configuration information. It contains constants
+ * used by many other classes.
+ *
+ * @author Sébastien Paumier
+ */
+public class Config {
+    /**
+     * Path of the directory <code>.../Unitex/App</code>
+     */
+    private static File applicationDir;
+    private static File unitexToolLogger;
+    
+    /**
+     * Path of the directory <code>.../Unitex</code>
+     */
+    private static File unitexDir;
+    /**
+     * Path of the user directory <code>.../(user dir)</code>
+     */
+    private static File userDir;
+    /**
+     * Current language. Languages must be in English, with the first letter in
+     * uppercase and the others in lowercase. Example: "French"
+     */
+    private static String currentLanguage;
+    /**
+     * Path of the user's current corpus
+     * <code>.../(user dir)/(current language)/Corpus/(my_corpus.snt)</code>
+     */
+    private static File currentSnt;
+    /**
+     * Path of the user's current corpus directory
+     * <code>.../(user dir)/(current language)/Corpus/(my_corpus_snt)</code>
+     */
+    private static File currentSntDir;
+    /**
+     * Path of the current cassys transducer list
+     */
+    private static File currentTransducerList;
+    public final static int WINDOWS_SYSTEM = 0;
+    public final static int LINUX_SYSTEM = 1;
+    public final static int MAC_OS_X_SYSTEM = 2;
+    public final static int SUN_OS_SYSTEM = 3;
+    /**
+     * Limit over which the concordance should be viewed with a web navigator
+     */
+    public final static int MAXIMUM_UTTERANCE_NUMBER_TO_DISPLAY_WITH_JAVA = 2000;
+    private static String currentSystemName;
+    /**
+     * Path of the user's current sentence delimitation graph
+     * <code>.../(user dir)/(current language)/Graphs/Preprocessing/Sentence/Sentence.grf</code>
+     */
+    private static File currentSentenceGraph;
+    /**
+     * Path of the user's current replace graph
+     * <code>.../(user dir)/(current language)/Graphs/Preprocessing/Replace/Replace.grf</code>
+     */
+    private static File currentReplaceGraph;
+    /**
+     * Path of the user's current normalization graph
+     * <code>.../(user dir)/(current language)/Graphs/Normalisation/Norm.grf</code>
+     */
+    private static File currentNormGraph;
+    /**
+     * Constant indicating under which system Unitex is running
+     */
+    private static int currentSystem = WINDOWS_SYSTEM;
+    private static String userName;
+    private static File currentDELA;
+    private static File currentConcordance;
+    /**
+     * Message shown when a text file is too large to be loaded.
+     */
+    public static final String FILE_TOO_LARGE_MESSAGE = "This file is too large to be displayed. Use a wordprocessor to view it.";
+    /**
+     * Empty file error message.
+     */
+    public static final String EMPTY_FILE_MESSAGE = "This file is empty.";
+    /**
+     * File reading error message.
+     */
+    public static final String ERROR_WHILE_READING_FILE_MESSAGE = "Cannot read this file.";
+    /**
+     * Dialog box used to open or save graphs
+     */
+    private static JFileChooser graphDialogBox;
+
+    private static final PersonalFileFilter pngFileFilter =
+            new PersonalFileFilter("png", "PNG Image");
+    private static final PersonalFileFilter svgFileFilter =
+            new PersonalFileFilter("svg", "Scalable Vector Graphics");
+    private static final PersonalFileFilter grfFileFilter =
+            new PersonalFileFilter("grf", "Unicode Graphs");
+
+    private static JFileChooser graphDiffDialogBox;
+    /**
+     * Dialog box used to choose a ".grf" or ".fst2" graph to be used in pattern
+     * matching
+     */
+    private static JFileChooser grfAndFst2DialogBox;
+    /**
+     * Dialog box used to choose the 'Sentence' graph
+     */
+    private static JFileChooser sentenceDialogBox;
+    /**
+     * Dialog box used to choose the 'Replace' graph
+     */
+    private static JFileChooser replaceDialogBox;
+    /**
+     * Dialog box used to choose the 'norm' graph
+     */
+    private static JFileChooser normDialogBox;
+    /**
+     * Dialog box used to choose the dictionary to be used with the Tagger
+     * program
+     */
+    private static JFileChooser taggerDataDialogBox;
+    /**
+     * Dialog box used to open ".txt" or ".snt" text files
+     */
+    private static JFileChooser corpusDialogBox;
+    /**
+     * Dialog box used to open  ".snt" text files
+     */
+    private static JFileChooser taggedCorpusDialogBox;
+    /**
+     * Dialog box used to open DELAF dictionaries. The file filter of this
+     * dialog box accepts ".dic" files, and also "dlf" and "dlc" files, that are
+     * text dictionaries.
+     */
+    private static JFileChooser delaDialogBox;
+    /**
+     * Dialog box used to select the directory where the inflection grammars are
+     * supposed to be
+     */
+    private static JFileChooser inflectDialogBox;
+    /**
+     * Dialog box used to open lexicon-grammars tables
+     */
+    private static JFileChooser tableDialogBox;
+    /**
+     * Dialog box used to open files to transcode
+     */
+    private static JFileChooser transcodeDialogBox;
+    /**
+     * Dialog box used to open files to edit
+     */
+    private static JFileChooser fileEditionDialogBox;
+    /**
+     * Dialog box used to open dictionary files to edit
+     */
+    private static JFileChooser dicFileEditionDialogBox;
+    /**
+     * Dialog box used to open text files to edit
+     */
+    private static JFileChooser txtFileEditionDialogBox;
+    /**
+     * Dialog box used to open cascade configuration files to edit
+     */
+    private static JFileChooser cscFileEditionDialogBox;
+    /**
+     * Dialog box used to choose an output text file for Fst2Unambig
+     */
+    private static JFileChooser fst2UnambigDialogBox;
+    /**
+     * Dialog box used to choose the transducer list file used with Cassys
+     */
+    private static JFileChooser transducerListDialogBox;
+    /**
+     * Dialog box used to choose an output text file for exporting graph paths
+     */
+    private static JFileChooser exploreGraphOutputDialogBox;
+
+    private static JFileChooser concordanceDialogBox;
+
+    /**
+     * Initializes the system. This method finds which system is running, which
+     * user is working. Then, it initializes dialog boxes and ask the user to
+     * choose the initial language he wants to work on. if appPath is not null,
+     * it is supposed to represent the directory in which the external programs
+     * are located.
+     */
+    public static void initConfig(String appPath) {
+        determineWhichSystemIsRunning();
+        determineUnitexDir(appPath);
+        determineCurrentUser();
+        chooseInitialLanguage();
+        setDefaultPreprocessingGraphs();
+    }
+
+    private static void updateGraphFileFilters(boolean allowImageFormats) {
+        graphDialogBox.resetChoosableFileFilters();
+        if (allowImageFormats) {
+            graphDialogBox.addChoosableFileFilter(pngFileFilter);
+            graphDialogBox.addChoosableFileFilter(svgFileFilter);
+            graphDialogBox.addChoosableFileFilter(grfFileFilter);
+        } else {
+            graphDialogBox.addChoosableFileFilter(grfFileFilter);
+        }
+        graphDialogBox.setFileFilter(grfFileFilter);
+    }
+
+    public static JFileChooser getGraphDialogBox(boolean allowImageFormats) {
+        if (graphDialogBox != null) {
+            if (!Unitex.isRunning()) {
+                graphDialogBox.setCurrentDirectory(ConfigManager.getManager()
+                    .getCurrentGraphDirectory());
+            }
+            updateGraphFileFilters(allowImageFormats);
+            return graphDialogBox;
+        }
+        graphDialogBox = new JFileChooser();
+        if (allowImageFormats) {
+            graphDialogBox.addChoosableFileFilter(pngFileFilter);
+            graphDialogBox.addChoosableFileFilter(svgFileFilter);
+        }
+        graphDialogBox.addChoosableFileFilter(grfFileFilter);
+        graphDialogBox.setFileFilter(grfFileFilter);
+        graphDialogBox.setDialogType(JFileChooser.OPEN_DIALOG);
+        graphDialogBox.setCurrentDirectory(ConfigManager.getManager()
+                .getCurrentGraphDirectory());
+        graphDialogBox.setMultiSelectionEnabled(true);
+        return graphDialogBox;
+    }
+
+    public static JFileChooser getGraphDiffDialogBox(File base) {
+        if (graphDiffDialogBox == null) {
+            graphDiffDialogBox = new JFileChooser();
+            graphDiffDialogBox.addChoosableFileFilter(grfFileFilter);
+            graphDiffDialogBox.setDialogType(JFileChooser.OPEN_DIALOG);
+            graphDiffDialogBox.setMultiSelectionEnabled(false);
+        }
+        graphDiffDialogBox.setFileFilter(grfFileFilter);
+        graphDiffDialogBox.setCurrentDirectory(base.getParentFile());
+        return graphDiffDialogBox;
+    }
+
+    public static JFileChooser getGrfAndFst2DialogBox() {
+        if (grfAndFst2DialogBox != null)
+            return grfAndFst2DialogBox;
+        grfAndFst2DialogBox = new JFileChooser();
+        grfAndFst2DialogBox.addChoosableFileFilter(new PersonalFileFilter(
+                "fst2", "Unicode Compiled Graphs"));
+        grfAndFst2DialogBox.addChoosableFileFilter(new PersonalFileFilter(
+                "grf", "Unicode Graphs"));
+        grfAndFst2DialogBox.setDialogType(JFileChooser.OPEN_DIALOG);
+        grfAndFst2DialogBox.setCurrentDirectory(ConfigManager.getManager()
+                .getCurrentGraphDirectory());
+        grfAndFst2DialogBox.setMultiSelectionEnabled(false);
+        return grfAndFst2DialogBox;
+    }
+
+    public static JFileChooser getSentenceDialogBox() {
+        if (sentenceDialogBox != null)
+            return sentenceDialogBox;
+        sentenceDialogBox = new JFileChooser();
+        sentenceDialogBox.addChoosableFileFilter(new PersonalFileFilter("grf",
+                "Unicode Graphs"));
+        PersonalFileFilter fstFilter = new PersonalFileFilter("fst2",
+                                           "Unicode Compiled Graphs");
+        sentenceDialogBox.addChoosableFileFilter(fstFilter);
+        sentenceDialogBox.setFileFilter(fstFilter);
+        sentenceDialogBox.setDialogType(JFileChooser.OPEN_DIALOG);
+        File f = new File(
+                ConfigManager.getManager().getCurrentGraphDirectory(),
+                "Preprocessing");
+        f = new File(f, "Sentence");
+        sentenceDialogBox.setCurrentDirectory(f);
+        sentenceDialogBox.setMultiSelectionEnabled(false);
+        return sentenceDialogBox;
+    }
+
+    public static JFileChooser getReplaceDialogBox() {
+        if (replaceDialogBox != null)
+            return replaceDialogBox;
+        replaceDialogBox = new JFileChooser();
+        replaceDialogBox.addChoosableFileFilter(new PersonalFileFilter("grf",
+                "Unicode Graphs"));
+        PersonalFileFilter fstFilter = new PersonalFileFilter("fst2",
+                                           "Unicode Compiled Graphs");
+        replaceDialogBox.addChoosableFileFilter(fstFilter);
+        replaceDialogBox.setFileFilter(fstFilter);
+        replaceDialogBox.setDialogType(JFileChooser.OPEN_DIALOG);
+        File f = new File(
+                ConfigManager.getManager().getCurrentGraphDirectory(),
+                "Preprocessing");
+        f = new File(f, "Replace");
+        replaceDialogBox.setCurrentDirectory(f);
+        replaceDialogBox.setMultiSelectionEnabled(false);
+        return replaceDialogBox;
+    }
+
+    public static JFileChooser getNormDialogBox() {
+        if (normDialogBox != null)
+            return normDialogBox;
+        normDialogBox = new JFileChooser();
+        normDialogBox.addChoosableFileFilter(new PersonalFileFilter("grf",
+                "Unicode Graphs"));
+        PersonalFileFilter fstFilter = new PersonalFileFilter("fst2",
+                                           "Unicode Compiled Graphs");
+        normDialogBox.addChoosableFileFilter(fstFilter);
+        normDialogBox.setFileFilter(fstFilter);
+        normDialogBox.setDialogType(JFileChooser.OPEN_DIALOG);
+        final File f = new File(ConfigManager.getManager()
+                .getCurrentGraphDirectory(), "Normalization");
+        normDialogBox.setCurrentDirectory(f);
+        normDialogBox.setMultiSelectionEnabled(false);
+        return normDialogBox;
+    }
+
+    public static JFileChooser getTaggerDataDialogBox() {
+        if (taggerDataDialogBox != null)
+            return taggerDataDialogBox;
+        taggerDataDialogBox = new JFileChooser();
+        PersonalFileFilter fstFilter = new PersonalFileFilter("fst2",
+                                           "Unicode Compiled Graphs");
+        taggerDataDialogBox.addChoosableFileFilter(fstFilter);
+        taggerDataDialogBox.setFileFilter(fstFilter);
+        taggerDataDialogBox.setDialogType(JFileChooser.OPEN_DIALOG);
+        taggerDataDialogBox.setCurrentDirectory(new File(Config
+                .getUserCurrentLanguageDir(), "Dela"));
+        taggerDataDialogBox.setMultiSelectionEnabled(false);
+        return taggerDataDialogBox;
+    }
+
+    public static JFileChooser getDelaDialogBox() {
+        if (delaDialogBox != null)
+            return delaDialogBox;
+        delaDialogBox = new JFileChooser();
+        PersonalFileFilter dicFilter = new PersonalFileFilter("dic",
+                                           "Unicode DELA Dictionaries");
+        delaDialogBox.addChoosableFileFilter(dicFilter);
+        delaDialogBox.setFileFilter(dicFilter);
+        delaDialogBox.setDialogType(JFileChooser.OPEN_DIALOG);
+        delaDialogBox.setCurrentDirectory(new File(Config
+                .getUserCurrentLanguageDir(), "Dela"));
+        delaDialogBox.setMultiSelectionEnabled(false);
+        return delaDialogBox;
+    }
+
+    public static JFileChooser getCorpusDialogBox() {
+        if (corpusDialogBox != null) {
+            return corpusDialogBox;
+        }
+        corpusDialogBox = new JFileChooser();
+        corpusDialogBox.addChoosableFileFilter(new PersonalFileFilter("xml",
+                "XML Files"));
+        corpusDialogBox.addChoosableFileFilter(new PersonalFileFilter("html",
+                "HTML Files"));
+        corpusDialogBox.addChoosableFileFilter(new PersonalFileFilter("snt",
+                "Unitex Text Files"));
+        PersonalFileFilter txtFilter = new PersonalFileFilter("txt",
+                                           "Text Files");
+        corpusDialogBox.addChoosableFileFilter(txtFilter);
+        corpusDialogBox.setFileFilter(txtFilter);
+        corpusDialogBox.setDialogType(JFileChooser.OPEN_DIALOG);
+        corpusDialogBox.setCurrentDirectory(Config.getCurrentCorpusDir());
+        corpusDialogBox.setMultiSelectionEnabled(false);
+        return corpusDialogBox;
+    }
+
+    public static JFileChooser getTaggedCorpusDialogBox() {
+        if (taggedCorpusDialogBox != null) {
+            return taggedCorpusDialogBox;
+        }
+        taggedCorpusDialogBox = new JFileChooser();
+        PersonalFileFilter sntFilter = new PersonalFileFilter("snt",
+                                       "Unitex Text Files");
+        taggedCorpusDialogBox.addChoosableFileFilter(sntFilter);
+        taggedCorpusDialogBox.setFileFilter(sntFilter);
+        taggedCorpusDialogBox.setDialogType(JFileChooser.OPEN_DIALOG);
+        taggedCorpusDialogBox.setCurrentDirectory(Config.getCurrentCorpusDir());
+        taggedCorpusDialogBox.setMultiSelectionEnabled(false);
+        return taggedCorpusDialogBox;
+    }
+
+    public static JFileChooser getInflectDialogBox(File dir) {
+        if (inflectDialogBox != null)
+            return inflectDialogBox;
+        inflectDialogBox = new JFileChooser();
+        inflectDialogBox.setDialogTitle("Choose the inflection directory");
+        inflectDialogBox.setDialogType(JFileChooser.OPEN_DIALOG);
+        inflectDialogBox.setFileSelectionMode(JFileChooser.DIRECTORIES_ONLY);
+        if (dir == null) {
+            dir = ConfigManager.getManager().getInflectionDir();
+        }
+        inflectDialogBox.setCurrentDirectory(dir);
+        return inflectDialogBox;
+    }
+
+    public static JFileChooser getTableDialogBox() {
+        if (tableDialogBox != null)
+            return tableDialogBox;
+        tableDialogBox = new JFileChooser();
+        PersonalFileFilter tableFilter = new PersonalFileFilter("txt",
+                                         "Unicode Text Tables");
+        tableDialogBox.addChoosableFileFilter(tableFilter);
+        tableDialogBox.setFileFilter(tableFilter);
+        tableDialogBox.setDialogType(JFileChooser.OPEN_DIALOG);
+        tableDialogBox.setCurrentDirectory(Config.getUserCurrentLanguageDir());
+        return tableDialogBox;
+    }
+
+    public static JFileChooser getTranscodeDialogBox() {
+        if (transcodeDialogBox != null)
+            return transcodeDialogBox;
+        transcodeDialogBox = new JFileChooser();
+        transcodeDialogBox.setDialogType(JFileChooser.OPEN_DIALOG);
+        transcodeDialogBox.setMultiSelectionEnabled(true);
+        transcodeDialogBox.setDialogTitle("Select files to transcode");
+        transcodeDialogBox.setCurrentDirectory(Config.getCurrentCorpusDir());
+        return transcodeDialogBox;
+    }
+
+    public static JFileChooser getFileEditionDialogBox() {
+        if (fileEditionDialogBox != null)
+            return fileEditionDialogBox;
+        fileEditionDialogBox = new JFileChooser();
+        fileEditionDialogBox.setDialogType(JFileChooser.OPEN_DIALOG);
+        fileEditionDialogBox.setMultiSelectionEnabled(false);
+        fileEditionDialogBox.setCurrentDirectory(Config.getCurrentCorpusDir());
+        fileEditionDialogBox.setDialogTitle("Select a file to edit");
+        return fileEditionDialogBox;
+    }
+    
+    public static JFileChooser initializeJFileChooser(JFileChooser jFileChooser,
+    		String extension, String description, String subfolder)
+    {
+    	if (jFileChooser != null)
+            return jFileChooser;
+        jFileChooser = new JFileChooser();
+        final PersonalFileFilter fileFilter=new PersonalFileFilter(extension,
+                description); 
+        jFileChooser.addChoosableFileFilter(fileFilter);
+        jFileChooser.setFileFilter(fileFilter);
+        jFileChooser.setDialogType(JFileChooser.OPEN_DIALOG);
+        jFileChooser.setCurrentDirectory(new File(Config
+                .getUserCurrentLanguageDir(), subfolder));
+        jFileChooser.setMultiSelectionEnabled(false);
+        jFileChooser.setDialogTitle("Select a file to edit");
+        return jFileChooser;
+    }
+    
+    public static JFileChooser getFileEditionDialogBox(String extension) {
+    	JFileChooser chooser;
+    	if(extension == null)
+    		chooser = getFileEditionDialogBox();
+    	else if(extension.equals("txt"))
+    		chooser = initializeJFileChooser(txtFileEditionDialogBox,"txt",
+    				"Text Files (*.txt)", "Corpus");
+    	else if(extension.equals("dic"))
+			chooser = initializeJFileChooser(dicFileEditionDialogBox,"dic",
+					"Unicode DELA Dictionaries  (*.dic)", "Dela");
+    	else if(extension.equals("csc"))
+			chooser = initializeJFileChooser(cscFileEditionDialogBox,"csc",
+					"Cascade Configuration Files (*.csc)", "CasSys");
+    	else
+    		chooser = getFileEditionDialogBox();
+    	return chooser;
+    }
+
+    public static JFileChooser getFst2UnambigDialogBox() {
+        if (fst2UnambigDialogBox != null)
+            return fst2UnambigDialogBox;
+        fst2UnambigDialogBox = new JFileChooser();
+        PersonalFileFilter txtFilter = new PersonalFileFilter("txt",
+                                          "Text Files");
+        fst2UnambigDialogBox.addChoosableFileFilter(txtFilter);
+        fst2UnambigDialogBox.setFileFilter(txtFilter);
+        fst2UnambigDialogBox.setDialogType(JFileChooser.OPEN_DIALOG);
+        fst2UnambigDialogBox.setCurrentDirectory(Config.getCurrentCorpusDir());
+        fst2UnambigDialogBox.setMultiSelectionEnabled(false);
+        return fst2UnambigDialogBox;
+    }
+
+    public static JFileChooser getTransducerListDialogBox() {
+        /*if (transducerListDialogBox != null) {
+            return transducerListDialogBox;
+        }
+        transducerListDialogBox = new JFileChooser(Config.getCassysDir());*/
+        if (transducerListDialogBox == null)
+            transducerListDialogBox = new JFileChooser(Config.getCassysDir());
+        if (transducerListDialogBox.getCurrentDirectory()
+                .getAbsolutePath()
+                .indexOf(Config.getUserCurrentLanguageDir()
+                    .getAbsolutePath()) == -1) {
+            transducerListDialogBox.setCurrentDirectory(Config.getCassysDir());
+        }
+        PersonalFileFilter cscFilter = new PersonalFileFilter("csc",
+                                           "CaSCade configuration File");
+        transducerListDialogBox.addChoosableFileFilter(cscFilter);
+        transducerListDialogBox.setFileFilter(cscFilter);
+        transducerListDialogBox.setDialogType(JFileChooser.OPEN_DIALOG);
+        // transducerListDialogBox.setCurrentDirectory(Config.getCassysDir());
+        transducerListDialogBox.setMultiSelectionEnabled(false);
+        //transducerListDialogBox.setControlButtonsAreShown(false);
+        return transducerListDialogBox;
+    }
+    
+    public static JFileChooser getExploreGraphOutputDialogBox() {
+        if (exploreGraphOutputDialogBox != null)
+            return exploreGraphOutputDialogBox;
+        exploreGraphOutputDialogBox = new JFileChooser();
+        PersonalFileFilter txtFilter =new PersonalFileFilter("txt",
+                                          "Text Files");
+        sentenceDialogBox.addChoosableFileFilter(txtFilter);
+        sentenceDialogBox.setFileFilter(txtFilter);
+        exploreGraphOutputDialogBox.setDialogType(JFileChooser.OPEN_DIALOG);
+        exploreGraphOutputDialogBox.setCurrentDirectory(Config.getUserCurrentLanguageDir());
+        exploreGraphOutputDialogBox.setMultiSelectionEnabled(false);
+        return exploreGraphOutputDialogBox;
+    }
+
+    public static JFileChooser getConcordanceDialogBox() {
+        if(concordanceDialogBox == null) {
+            concordanceDialogBox = new JFileChooser(Config.getCurrentSntDir());
+            PersonalFileFilter htmlFilter = new PersonalFileFilter("html",
+                                                "HTML Files");
+            concordanceDialogBox.addChoosableFileFilter(htmlFilter);
+            concordanceDialogBox.setFileFilter(htmlFilter);
+            concordanceDialogBox.setDialogType(JFileChooser.OPEN_DIALOG);
+            concordanceDialogBox.setMultiSelectionEnabled(false);
+        }
+        return concordanceDialogBox;
+    }
+
+    /**
+     * Updates working directories of dialog boxes. This method is called when
+     * the user changes of working language.
+     */
+    private static void updateOpenSaveDialogBoxes() {
+        if (graphDialogBox != null) {
+            graphDialogBox.setCurrentDirectory(Config.getCurrentGraphDir());
+        }
+        if (grfAndFst2DialogBox != null)
+            grfAndFst2DialogBox
+                    .setCurrentDirectory(Config.getCurrentGraphDir());
+        if (sentenceDialogBox != null)
+            sentenceDialogBox.setCurrentDirectory(new File(new File(Config
+                    .getCurrentGraphDir(), "Preprocessing"), "Sentence"));
+        if (replaceDialogBox != null)
+            replaceDialogBox.setCurrentDirectory(new File(new File(Config
+                    .getCurrentGraphDir(), "Preprocessing"), "Replace"));
+        if (corpusDialogBox != null)
+            corpusDialogBox.setCurrentDirectory(Config.getCurrentCorpusDir());
+        if (taggedCorpusDialogBox != null)
+            taggedCorpusDialogBox.setCurrentDirectory(Config.getCurrentCorpusDir());
+        if (delaDialogBox != null)
+            delaDialogBox.setCurrentDirectory(new File(Config
+                    .getUserCurrentLanguageDir(), "Dela"));
+        if (inflectDialogBox != null)
+            inflectDialogBox.setCurrentDirectory(new File(Config
+                    .getUserCurrentLanguageDir(), "Inflection"));
+        if (tableDialogBox != null)
+            tableDialogBox.setCurrentDirectory(Config
+                    .getUserCurrentLanguageDir());
+        if (transcodeDialogBox != null)
+            transcodeDialogBox
+                    .setCurrentDirectory(Config.getCurrentCorpusDir());
+        if (fileEditionDialogBox != null)
+            fileEditionDialogBox.setCurrentDirectory(Config
+                    .getCurrentCorpusDir());
+        if (fst2UnambigDialogBox != null)
+            fst2UnambigDialogBox.setCurrentDirectory(Config
+                    .getCurrentCorpusDir());
+        if (taggerDataDialogBox != null)
+            taggerDataDialogBox.setCurrentDirectory(new File(Config
+                    .getUserCurrentLanguageDir(), "Dela"));
+        if(concordanceDialogBox != null) {
+            concordanceDialogBox.setCurrentDirectory(Config.getCurrentSntDir());
+        }
+    }
+
+    /**
+     * Finds the path of the Unitex directory. Sets up the application
+     * directory. If appPath is not null, it represents the external programs
+     * directory.
+     */
+    private static void determineUnitexDir(String appPath) {
+        setApplicationDir(appPath, new File(System.getProperty("user.dir")));
+    }
+
+    /**
+     * Finds the user's name. If the user works with Unitex for the first time,
+     * he is asked for choosing his private working directory if he works under
+     * Windows. Under Linux or MacOS, his private directory is a directory named
+     * "unitex", created in his home directory.
+     */
+    private static void determineCurrentUser() {
+        userName = System.getProperty("user.name");
+        if (currentSystem == WINDOWS_SYSTEM) {
+            // configuration procedure under Windows
+            final File directory = new File(getUnitexDir(), "Users");
+            if (!directory.exists()) {
+                directory.mkdir();
+            }
+            File userFile = new File(new File(getUnitexDir(), "Users"),
+                    userName + ".cfg");
+            if (!userFile.exists() || !userFile.getParentFile().canWrite()) {
+                /*
+                 * Windows 7 forbids writing in Users if Unitex is in 'Program
+                 * Files', so we try to look for a home dir
+                 */
+                if (System.getProperty("user.home") != null) {
+                    userFile = new File(System.getProperty("user.home"),
+                            ".unitex.cfg");
+                } else {
+                    JOptionPane
+                            .showMessageDialog(
+                                    null,
+                                    "Unable to find a consistent writable location\nto store your configuration file",
+                                    "Welcome", JOptionPane.PLAIN_MESSAGE);
+                    System.exit(1);
+                }
+            }
+            if (!userFile.exists()) {
+                try {
+                    chooseNewUserDir();
+                    userFile.createNewFile();
+                    final BufferedWriter bw = new BufferedWriter(
+                            new FileWriter(userFile));
+                    bw.write(getUserDir().getAbsolutePath(), 0, getUserDir()
+                            .getAbsolutePath().length());
+                    bw.close();
+                } catch (final IOException e) {
+                    e.printStackTrace();
+                }
+            } else {
+                try {
+                    final BufferedReader br = new BufferedReader(
+                            new FileReader(userFile));
+                    String s = br.readLine();
+                    if (s == null || s.equals("")) {
+                        System.out.println("Error: " + userFile + " is empty!");
+                        s = null;
+                    }
+                    setUserDir(new File(s));
+                    br.close();
+                } catch (final IOException e) {
+                    System.out.println("Error: " + userFile + " is empty!");
+                    e.printStackTrace();
+                }
+            }
+            return;
+        }
+        if ((currentSystem == LINUX_SYSTEM)
+                || (currentSystem == MAC_OS_X_SYSTEM)
+                || (currentSystem == SUN_OS_SYSTEM)) {
+            /* The default user directory is /home/user/unitex */
+            File rep = new File(System.getProperty("user.home"), "unitex");
+            final File config = new File(System.getProperty("user.home"),
+                    ".unitex.cfg");
+            if (config.exists()) {
+                FileInputStream s;
+                try {
+                    s = new FileInputStream(config);
+                    final Scanner scanner = new Scanner(s, "UTF8");
+                    if (scanner.hasNextLine()) {
+                        // try to check if the directory pointed by .unitex.cfg
+                        // is a valid directory path
+                        final File unitex_config_file = new File(scanner.nextLine());
+                        try {
+                            final String unitex_config_canonical_path =
+                            unitex_config_file.getCanonicalPath();
+                            // /foo/c:\bar is considered a wrong directory path
+                            if(unitex_config_canonical_path.indexOf('/')  >= 0 &&
+                               unitex_config_canonical_path.indexOf('\\') >= 0) {
+                                unitex_config_file.delete();
+                            } else {
+                                rep = unitex_config_file;
+                            }
+                        }
+                        catch (IOException e) {
+                          // Direcory pointed by unitex_config isn't a valid path
+                        }
+                    }
+                    scanner.close();
+                    s.close();
+                } catch (final FileNotFoundException e) {
+                    e.printStackTrace();
+                } catch (final IOException e) {
+                    e.printStackTrace();
+                }
+            }
+            if (!rep.exists()) {
+                // if the directory does not exist, we inform the user
+                String message = "Welcome " + getUserName() + "!\n\n";
+                message = message
+                        + "Your private Unitex directory where you can\nstore your own data is:\n\n";
+                message = message + rep + "\n";
+                JOptionPane.showMessageDialog(null, message, "Welcome",
+                        JOptionPane.PLAIN_MESSAGE);
+            }
+            setUserDir(rep);
+            return;
+        }
+        throw new IllegalStateException(
+                "Unitex is not configured for this system!");
+    }
+
+    /**
+     * Finds which operating system is used. If the system is not supported by
+     * Unitex, the program behaves as for a Linux one.
+     */
+    private static void determineWhichSystemIsRunning() {
+        currentSystemName = System.getProperty("os.name");
+        currentSystem = getSystem();
+        System.out.println("Unitex is running under " + currentSystemName);
+    }
+
+    public static int getSystem() {
+        final String currentSystemName1 = System.getProperty("os.name");
+        int currentSystem1 = -1;
+        if (currentSystemName1.equalsIgnoreCase("Windows NT")
+                || currentSystemName1.equalsIgnoreCase("Windows 2003")
+                || currentSystemName1.equalsIgnoreCase("Windows 2000")
+                || currentSystemName1.equalsIgnoreCase("Windows 98")
+                || currentSystemName1.equalsIgnoreCase("Windows 95")
+                || currentSystemName1.equalsIgnoreCase("Windows XP")
+                || currentSystemName1.equalsIgnoreCase("Windows ME")
+                || currentSystemName1.equalsIgnoreCase("Windows Server 2008")
+                || currentSystemName1.equalsIgnoreCase("Windows Vista")
+                || currentSystemName1.equalsIgnoreCase("Windows 7")
+                || currentSystemName1.toLowerCase().indexOf("windows") >= 0) {
+            currentSystem1 = WINDOWS_SYSTEM;
+        } else if (currentSystemName1.equalsIgnoreCase("linux")) {
+            currentSystem1 = LINUX_SYSTEM;
+        } else if (currentSystemName1.equalsIgnoreCase("mac os x")
+                || currentSystemName1.equalsIgnoreCase("Darwin")) {
+            currentSystem1 = MAC_OS_X_SYSTEM;
+        } else if (currentSystemName1.equalsIgnoreCase("sunos")) {
+            currentSystem1 = SUN_OS_SYSTEM;
+        } else {
+            /* By default, we assume that a have a linux compatible system */
+            currentSystem1 = LINUX_SYSTEM;
+        }
+        return currentSystem1;
+    }
+
+    /**
+     * @return the current system constant
+     */
+    public static int getCurrentSystem() {
+        return currentSystem;
+    }
+
+    /**
+     * @return the current system name
+     */
+    public static String getCurrentSystemName() {
+        return currentSystemName;
+    }
+
+    /**
+     * @return the application directory
+     */
+    public static File getApplicationDir() {
+        if (applicationDir == null) {
+            System.err.println("ERROR in getApplicationDir()");
+        }
+        return applicationDir;
+    }
+
+    public static File getUnitexToolLogger() {
+        return unitexToolLogger;
+    }
+
+    /**
+     * Returns the UnitexToolLogger semantic version
+     * <code>UnitexToolLogger VersionInfo -s</code>
+     * e.g. 3.1.4239-beta
+     *
+     * @author martinec
+     */
+    public static String getUnitexToolLoggerSemVer() {
+      String semver = "?";
+      try {
+          CommandBuilder cmd = new VersionInfoCommand().getSemver();
+          String[] comm = cmd.getCommandArguments(true);
+          
+          final Process p = Runtime.getRuntime().exec(comm);
+          final BufferedReader in = new BufferedReader(
+                  new InputStreamReader(p.getInputStream(), "UTF8"));
+          String s = in.readLine();
+          if (s != null) {
+              if (s.endsWith("\n") || s.endsWith("\r")) {
+                      s = s.substring(0, s.length() - 1);
+              }
+              semver = s;
+          }
+          p.waitFor();
+          in.close();
+      } catch (final IOException e) {
+      } catch (InterruptedException e) {
+      }
+
+      return semver;
+    }
+
+    /**
+     * Sets the application directory
+     *
+     * @param appPath
+     *            if not null, it represents the external programs directory
+     * @param s
+     *            directory's path
+     */
+    private static void setApplicationDir(String appPath, File s) {
+        if (appPath != null) {
+            applicationDir = new File(appPath);
+        } else {
+            applicationDir = s;
+        }
+        unitexToolLogger = setupUnitexToolLogger(applicationDir);
+        setUnitexDir(applicationDir.getParentFile());
+    }
+
+    /**
+     * Setup the UnitexToolLogger executable
+     * 
+     * @param path
+     *            external programs directory
+     *
+     * @author martinec
+     */
+    public static File setupUnitexToolLogger(File path) {        
+        // define the default unitexToolLogger path
+        File UnitexToolLogger = new File(path, "UnitexToolLogger" +
+        (Config.getSystem() == Config.WINDOWS_SYSTEM ? ".exe" : ""));
+
+        // if UnitexToolLogger does not exists and we are not running under
+        // Windows, try to install it
+        if(!UnitexToolLogger.exists() &&
+            Config.getSystem() != Config.WINDOWS_SYSTEM) {
+            // define the default setup script path    
+            File setupScript = new File(path, "install" + File.separatorChar + "setup");
+            if(setupScript.exists()) {
+                // setup ProcessBuilder
+                // Java 6+ alternative to redirect output and hence in our case
+                // avoid process hangs
+                // @see https://github.com/avl42/lanterna/commit/1bdb64fa
+                StringBuilder sb = new StringBuilder();
+                sb.append(setupScript.getAbsolutePath()).append(' ');
+                sb.append("> ").append("install" + File.separatorChar + "setup.log");
+                String cmd[] = new String[] { "sh", "-c", sb.toString() };                
+                final ProcessBuilder pb = new ProcessBuilder(cmd);
+                
+                // Java 7+ only
+                //final ProcessBuilder pb = new ProcessBuilder(setupScript.getAbsolutePath());
+                //pb.redirectOutput(ProcessBuilder.Redirect.INHERIT);
+
+                pb.directory(path);
+                pb.redirectErrorStream(true);
+                
+                // show a "Please wait" message dialog. This was adapted from
+                // @source http://www.coding-dude.com/wp/java/modal-progress-bar-dialog-java-swing
+                java.awt.Frame f=null;
+
+                final JDialog dlgProgress = new JDialog(f, "Please wait until installation is finished", true);
+                dlgProgress.setAlwaysOnTop(true);
+                
+                JLabel lblStatus = new JLabel("Compiling " + UnitexToolLogger.getName() + "...");
+                
+                JProgressBar pbProgress = new JProgressBar(0, 100);
+                pbProgress.setIndeterminate(true);
+
+                dlgProgress.add(BorderLayout.NORTH, lblStatus);
+                dlgProgress.add(BorderLayout.CENTER, pbProgress);
+                
+                // prevent the user from closing the dialog
+                dlgProgress.setDefaultCloseOperation(JDialog.DO_NOTHING_ON_CLOSE);
+
+                dlgProgress.setSize(400, 90);
+            
+                // center on screen
+                Dimension screenSize = Toolkit.getDefaultToolkit().getScreenSize();
+                dlgProgress.setLocation((screenSize.width  - dlgProgress.getWidth())  / 2,
+                                        (screenSize.height - dlgProgress.getHeight()) / 2);
+
+                // SwingWorker
+                SwingWorker<Void, Void> sw = new SwingWorker<Void, Void>() {
+                 @Override
+                 protected Void doInBackground() throws Exception {
+                  // execute the setup script
+                  try {                  
+                      // star script
+                      Process p = pb.start();
+                      // wait to finish
+                      p.waitFor();
+                  } catch (Exception e) {
+                      // do nothing
+                  } 
+                  return null;
+                 }
+
+                 @Override
+                 protected void done() {
+                    //close the modal dialog 
+                    dlgProgress.dispose();
+                 }
+                };
+
+                // this will start the processing on a separate thread
+                sw.execute();
+                //this will block user input as long as the processing task is working
+                dlgProgress.setVisible(true);
+            }
+        }
+        
+        // check if UnitexToolLogger exists
+        if(!UnitexToolLogger.exists()) {
+          JOptionPane.showMessageDialog(null,
+                                    UnitexToolLogger.getAbsolutePath() +
+                                    " not found!\nSee the README for"  +
+                                    " detailed installation instructions",
+                                    UnitexToolLogger.getName() + " not found",
+                                    JOptionPane.INFORMATION_MESSAGE);
+        }
+        
+        return UnitexToolLogger;
+    }
+
+    /**
+     * @return the Unitex directory
+     */
+    public static File getUnitexDir() {
+        if (unitexDir == null) {
+            System.err.println("ERROR in getUnitexDir()");
+        }
+        return unitexDir;
+    }
+
+    /**
+     * Sets the system directory
+     *
+     * @param s
+     *            directory's path
+     */
+    private static void setUnitexDir(File s) {
+        unitexDir = s;
+    }
+
+    /**
+     * @return the user directory
+     */
+    public static File getUserDir() {
+        if (userDir == null) {
+            System.err.println("ERROR in getUserDir()");
+        }
+        return userDir;
+    }
+
+    /**
+     * Sets the user directory
+     *
+     * @param folder_Location
+     *            directory's path
+     */
+    
+    public static void setUserDir(File s) {
+        userDir = s;
+        if (!userDir.exists()) {
+            // if the directory does not exists, we create it
+            if (!userDir.mkdir()) {
+                System.err.println("Fatal error: cannot create directory "
+                        + userDir);
+                System.exit(1);
+            }
+        }
+    }
+
+    /**
+     * @return the current language
+     */
+    public static String getCurrentLanguage() {
+        if (currentLanguage == null) {
+            System.err.println("ERROR in getCurrentLanguage()");
+        }
+        return currentLanguage;
+    }
+
+    /**
+     * Sets the current language. All directories that depend of this one are
+     * updated. Preferences all also updated
+     *
+     * @param s
+     *            language's name
+     */
+    public static void setCurrentLanguage(String s) {
+        currentLanguage = s;
+        setUserCurrentLanguageDir(new File(getUserDir(), currentLanguage));
+        setDefaultPreprocessingGraphs();
+        updateOpenSaveDialogBoxes();
+        fireLanguageChanged();
+    }
+
+    public static File getCurrentTransducerList() {
+        return currentTransducerList;
+    }
+
+    public static void setCurrentTransducerList(File f) {
+        currentTransducerList = f;
+    }
+
+    public static File getCassysDir() {
+        return new File(getUserCurrentLanguageDir(), "CasSys");
+    }
+
+    private static final String[] bastien = new String[] { "Greek (Ancient)",
+            "grec momifié", "grec putréfié", "grec embaumé", "grec faisandé",
+            "grec mort", "vieux grec tout rabougri",
+            "grec qui sent la naphtaline", "grec périmé", "grec cadavérique",
+            "grec de morgue",
+            "grec tellement vieux qu'on frôle la profanation",
+            "grec médico-légal", "grec grouillant d'insectes nécrophages",
+            "grec en décomposition",
+            "grec moisi (les fameux champignons à la grecque)",
+            "grec qui ferait vomir un marchand de kébabs de rat",
+            "grec pourri", "grec desséché" };
+    private static final String[] jeesun = new String[] {
+            "\uC9C0\uC21C\uC744 \uC704\uD55C \uD55C\uAD6D\uC5B4",
+            "2000\uB144 \uB3D9\uC548\uC758 \uD55C\uAD6D\uC5B4",
+            "\uC0C8\uBCBD 4\uC2DC\uC758 \uD55C\uAD6D\uC5B4",
+            "\uAC74\uBC30\uB77C\uB294 \uB2E8\uC5B4\uB9CC\uC744 \uD560 \uC904 \uC544\uB294 \uC0AC\uB78C\uC758 \uD55C\uAD6D\uC5B4",
+            "\uD55C\uAD6D\uC5B4\uC640 \uC220",
+            "coréen rien que pour toi toute seule" };
+
+    /**
+     * @return the current language to be displayed in the title bar
+     */
+    public static String getCurrentLanguageForTitleBar() {
+        if (currentLanguage == null) {
+            System.err.println("ERROR in getCurrentLanguageForTitleBar()");
+            return null;
+        }
+        /* The following is a private joke */
+        if (currentLanguage.equals("Greek (Ancient)")
+                && (getUserName().equalsIgnoreCase("bastien") || getUserName()
+                        .equalsIgnoreCase("nastasia"))) {
+            return bastien[new Random().nextInt(bastien.length)];
+        }
+        /* This one too */
+        if (currentLanguage.equals("KoreanJeeSun")) {
+            return jeesun[new Random().nextInt(jeesun.length)];
+        }
+        if (getUserName().hashCode() == 549477927) {
+            return "\u2665\u2665\u2665 " + currentLanguage
+                    + " \u2665\u2665\u2665";
+        }
+        return currentLanguage;
+    }
+
+    /**
+     * @return system's current language directory
+     */
+    public static File getUnitexCurrentLanguageDir() {
+        return new File(getUnitexDir(), getCurrentLanguage());
+    }
+
+    /**
+     * @return the users' current language directory
+     */
+    public static File getUserCurrentLanguageDir() {
+        return new File(getUserDir(), getCurrentLanguage());
+    }
+
+    /**
+     * Sets the user's current language directory. If some sub-directories are
+     * missing, they are copied from the system's current language directory
+     * with all their files, excepting the dictionaries (".bin" and ".inf"
+     * files).
+     *
+     * @param s
+     *            directory's path
+     */
+    private static void setUserCurrentLanguageDir(File userCurrentLanguageDir) {
+        // now, we verify if the directory exists
+        if (!userCurrentLanguageDir.exists()) {
+            // if the path does not exists
+            if (!userCurrentLanguageDir.mkdir()) {
+                System.err.println("ERROR: cannot create directory "
+                        + userCurrentLanguageDir.getAbsolutePath());
+                System.exit(1);
+            }
+            FileUtil.copyFileByName(
+                    new File(getUnitexCurrentLanguageDir(), "*"),
+                    getUserCurrentLanguageDir());
+        }
+        // if any of the sub-directories does not exist, we create it
+        File f = new File(userCurrentLanguageDir, "Corpus");
+        if (!f.exists()) {
+            f.mkdir();
+            FileUtil.copyDirRec(new File(getUnitexCurrentLanguageDir(),
+                    "Corpus"), f);
+        }
+        f = new File(userCurrentLanguageDir, "Elag");
+        if (!f.exists()) {
+            FileUtil.copyDirRec(
+                    new File(getUnitexCurrentLanguageDir(), "Elag"), f);
+        }
+        f = new File(userCurrentLanguageDir, "Inflection");
+        if (!f.exists()) {
+            FileUtil.copyDirRec(new File(getUnitexCurrentLanguageDir(),
+                    "Inflection"), f);
+        }
+        f = new File(userCurrentLanguageDir, "Dela");
+        if (!f.exists()) {
+            f.mkdir();
+        }
+        f = new File(userCurrentLanguageDir, "Graphs");
+        if (!f.exists()) {
+            FileUtil.copyDirRec(new File(getUnitexCurrentLanguageDir(),
+                    "Graphs"), f);
+        }
+        f = new File(userCurrentLanguageDir, "CasSys");
+        if (!f.exists()) {
+            FileUtil.copyDirRec(new File(getUnitexCurrentLanguageDir(),
+                    "CasSys"), f);
+        }
+    }
+
+    /**
+     * @return user's current corpus directory
+     */
+    public static File getCurrentCorpusDir() {
+        return new File(getUserCurrentLanguageDir(), "Corpus");
+    }
+
+    /**
+     * @return user's current graph directory
+     */
+    public static File getCurrentGraphDir() {
+        return new File(getUserCurrentLanguageDir(), "Graphs");
+    }
+
+    /**
+     * @return user's current ELAG directory
+     */
+    public static File getCurrentElagDir() {
+        return new File(getUserCurrentLanguageDir(), "Elag");
+    }
+
+    /**
+     * @return user's name
+     */
+    public static String getUserName() {
+        return userName;
+    }
+
+    /**
+     * Asks for the user to select his private directory. IMPORTANT: this method
+     * must be called only when Unitex is running under Windows.
+     */
+    private static void chooseNewUserDir() {
+        String message = "Welcome " + getUserName() + "!\n\n";
+        message = message
+                + "To use Unitex, you must choose a private \ndirectory to store your data ";
+        message = message + "(that you\ncan change later if you want).";
+        message = message + "\n\nClick on OK to choose your directory.";
+        JOptionPane.showMessageDialog(null, message, "Welcome",
+                JOptionPane.PLAIN_MESSAGE);
+        final JFileChooser f = new JFileChooser();
+        f.setDialogTitle("Choose your private directory");
+        f.setDialogType(JFileChooser.OPEN_DIALOG);
+        f.setFileSelectionMode(JFileChooser.DIRECTORIES_ONLY);
+        while (f.showOpenDialog(null) != JFileChooser.APPROVE_OPTION || /*
+                                                                         * areIdenticalDirectories
+                                                                         * ( f.
+                                                                         * getSelectedFile
+                                                                         * ().
+                                                                         * getAbsolutePath
+                                                                         * (),
+                                                                         * getUnitexDir
+                                                                         * ())
+                                                                         */
+        f.getSelectedFile().equals(getUnitexDir())) {
+            if (f.showOpenDialog(null) != JFileChooser.APPROVE_OPTION) {
+                message = "You must choose a private directory.\n\n";
+                message = message + "Click on OK to select one or on\n";
+                message = message + "Cancel to exit.";
+            } else {
+                message = "You cannot choose the Unitex directory as your private one";
+            }
+            final String[] options = { "OK", "Cancel" };
+            final int n = JOptionPane.showOptionDialog(null, message, "Error",
+                    JOptionPane.YES_NO_OPTION, JOptionPane.ERROR_MESSAGE, null,
+                    options, options[0]);
+            if (n == 1)
+                System.exit(0);
+        }
+        setUserDir(f.getSelectedFile());
+    }
+
+    /**
+     * Asks for the user to change his private directory. IMPORTANT: this method
+     * must be called only when Unitex is running under Windows.
+     */
+    public static void changeUserDir() {
+        final JFileChooser f = new JFileChooser();
+        f.setDialogTitle("Choose your private directory");
+        f.setDialogType(JFileChooser.OPEN_DIALOG);
+        f.setFileSelectionMode(JFileChooser.DIRECTORIES_ONLY);
+        if (f.showOpenDialog(null) != JFileChooser.APPROVE_OPTION)
+            return;
+        if (f.getSelectedFile().equals(getUnitexDir())) {
+            JOptionPane
+                    .showMessageDialog(
+                            null,
+                            "You cannot choose the Unitex directory as your private one",
+                            "Error", JOptionPane.ERROR_MESSAGE);
+            return;
+        }
+        setUserDir(f.getSelectedFile());
+    }
+
+    public static void collectLanguage(File directory, Set<String> languages) {
+        final File[] fileList = directory.listFiles(new FileFilter() {
+            @Override
+            public boolean accept(File file) {
+                return file.isDirectory()
+                        && ConfigManager.getManager().isValidLanguageName(
+                                file.getName());
+            }
+        });
+        for (final File aFileList : fileList) {
+            languages.add(aFileList.getName());
+        }
+    }
+
+    /**
+     * Shows a dialog box that offers to the user to choose the initial language
+     * he wants to work on
+     */
+    private static void chooseInitialLanguage() {
+        final JPanel p = new JPanel();
+        p.setLayout(new GridLayout(4, 1));
+        p.setOpaque(true);
+        final TreeSet<String> languages = new TreeSet<String>();
+        collectLanguage(getUnitexDir(), languages);
+        collectLanguage(getUserDir(), languages);
+        
+        String [] langArr = languages.toArray(new String[0]);
+        int defaultLangIndex = -1;
+        String preferedLanguage = PreferencesManager.getUserPreferences().getPreferedLanguage();
+        if(preferedLanguage != null)
+        	for(int i=0; i<langArr.length &&  defaultLangIndex == -1; i++)
+        		if(preferedLanguage.equals(langArr[i]))
+        				defaultLangIndex = i;
+        		
+        final JComboBox langList = new JComboBox(langArr);
+        if(defaultLangIndex != -1)
+        	langList.setSelectedIndex(defaultLangIndex);
+        
+        p.add(new JLabel("User: " + getUserName()));
+        p.add(new JLabel("Choose the language you want"));
+        p.add(new JLabel("to work on:"));
+        p.add(langList);
+        
+        final JFrame frame = new JFrame();
+        frame.setAlwaysOnTop(true);
+        final String[] options = { "OK", "Exit" };
+        if (1 == JOptionPane.showOptionDialog(frame, p, "Unitex",
+                JOptionPane.YES_NO_OPTION, JOptionPane.QUESTION_MESSAGE, null,
+                options, options[0])) {
+            System.exit(0);
+        }
+        String selectedItem = (String) (langList.getSelectedItem());
+        setCurrentLanguage(selectedItem);
+        PreferencesManager.getUserPreferences().setPreferedLanguage(selectedItem);
+        
+    }
+
+    /**
+     * Shows a dialog box that offers to the user to change the language he
+     * works on. If they are some frames that depend on the language (corpus
+     * frame, token frame, etc), they are all closed before changing the working
+     * language.
+     */
+    public static void changeLanguage() {
+        final TreeSet<String> languages = new TreeSet<String>();
+        collectLanguage(getUnitexDir(), languages);
+        collectLanguage(getUserDir(), languages);
+        final JComboBox langList = new JComboBox(languages.toArray());
+        final String old = getCurrentLanguage();
+        final String[] options = { "OK", "Cancel" };
+        if (0 == JOptionPane.showOptionDialog(null, langList,
+                "Choose a language", JOptionPane.YES_NO_OPTION,
+                JOptionPane.QUESTION_MESSAGE, null, options, options[0])) {
+            final String newLanguage = (String) (langList.getSelectedItem());
+            if (!old.equals(newLanguage)) {
+                setCurrentLanguage(newLanguage);
+            }
+        }
+    }
+
+    /**
+     * @return current corpus
+     */
+    public static File getCurrentSnt() {
+        return currentSnt;
+    }
+
+    /**
+     * Sets the current corpus
+     *
+     * @param s
+     *            name of the corpus file
+     */
+    public static void setCurrentSnt(File s) {
+        currentSnt = s;
+        setCurrentSntDir(s);
+    }
+
+    /**
+     * @return current corpus
+     */
+    public static File getCurrentSntDir() {
+        return currentSntDir;
+    }
+
+    /**
+     * Sets the current corpus
+     *
+     * @param s
+     *            name of the corpus file
+     */
+    private static void setCurrentSntDir(File s) {
+        if (s == null) {
+            currentSntDir = null;
+            return;
+        }
+        final String path = FileUtil.getFileNameWithoutExtension(s
+                .getAbsolutePath());
+        currentSntDir = new File(path + "_snt");
+        if (currentSntDir.exists() && !currentSntDir.isDirectory()) {
+            JOptionPane.showMessageDialog(null, currentSntDir.getAbsolutePath()
+                    + " is not a directory but a file.\n"
+                    + "\nUnitex will abort.", "Fatal error",
+                    JOptionPane.ERROR_MESSAGE);
+            System.exit(1);
+        }
+    }
+
+    /**
+     * @return current sentence delimitation graph
+     */
+    public static File getCurrentSentenceGraph() {
+        return currentSentenceGraph;
+    }
+
+    /**
+     * Sets current sentence delimitation graph
+     *
+     * @param s
+     *            graph's name
+     */
+    private static void setCurrentSentenceGraph(File s) {
+        currentSentenceGraph = s;
+    }
+
+    /**
+     * @return current replace graph
+     */
+    public static File getCurrentReplaceGraph() {
+        return currentReplaceGraph;
+    }
+
+    /**
+     * Sets current replace graph
+     *
+     * @param s
+     *            graph's name
+     */
+    private static void setCurrentReplaceGraph(File s) {
+        currentReplaceGraph = s;
+    }
+
+    /**
+     * @return current sentence normalization graph
+     */
+    public static File getCurrentNormGraph() {
+        return currentNormGraph;
+    }
+
+    /**
+     * Sets current sentence normalization graph
+     *
+     * @param s
+     *            graph's name
+     */
+    public static void setCurrentNormGraph(File s) {
+        currentNormGraph = s;
+    }
+
+    /**
+     * Sets sentence delimitation and replace graphs
+     */
+    private static void setDefaultPreprocessingGraphs() {
+        File sentence = new File(getUserCurrentLanguageDir(), "Graphs");
+        sentence = new File(sentence, "Preprocessing");
+        File replace = new File(getUserCurrentLanguageDir(), "Replace");
+        replace = new File(replace, "Replace");
+        if (getCurrentLanguage().equals("Thai")) {
+            // this is an exception because we do not have anymore
+            // the .grf file
+            sentence = new File(sentence, "Sentence.fst2");
+        } else {
+            sentence = new File(sentence, "Sentence.grf");
+        }
+        replace = new File(replace, "Replace.grf");
+        setCurrentSentenceGraph(sentence);
+        setCurrentReplaceGraph(replace);
+        File z = new File(getUserCurrentLanguageDir(), "Graphs");
+        z = new File(z, "Normalization");
+        z = new File(z, "Norm.grf");
+        setCurrentNormGraph(z);
+    }
+
+    /**
+     * Sets current DELA
+     *
+     * @param s
+     *            dictionary name
+     */
+    public static void setCurrentDELA(File s) {
+        currentDELA = s;
+    }
+
+    /**
+     * @return current DELA's name
+     */
+    public static File getCurrentDELA() {
+        return currentDELA;
+    }
+
+    public static File getCurrentConcordance() {
+        return currentConcordance;
+    }
+
+    public static void setCurrentConcordance(File s) {
+        currentConcordance = s;
+    }
+
+    public static File getXAlignDirectory() {
+        final File dir = new File(Config.getUserDir(), "XAlign");
+        if (!dir.exists()) {
+            final File foo = new File(Config.getUnitexDir(), "XAlign");
+            if (!foo.exists()) {
+                JOptionPane.showMessageDialog(null, "Cannot find directory "
+                        + foo.getAbsolutePath(), "Error",
+                        JOptionPane.ERROR_MESSAGE);
+                return null;
+            }
+            FileUtil.copyDirRec(foo, dir);
+        }
+        return dir;
+    }
+
+    public static File getAlignmentProperties() {
+        final File dir = getXAlignDirectory();
+        final File f = new File(dir, "multialign.properties");
+        if (!f.exists()) {
+            final File tmp = new File(
+                    new File(Config.getUnitexDir(), "XAlign"),
+                    "multialign.properties");
+            if (!tmp.exists()) {
+                JOptionPane.showMessageDialog(
+                        null,
+                        "Cannot find XAlign configuration file "
+                                + tmp.getAbsolutePath(), "Error",
+                        JOptionPane.ERROR_MESSAGE);
+                return null;
+            }
+            FileUtil.copyFile(tmp, f);
+        }
+        return f;
+    }
+
+    public static ArrayList<File> getDefaultDicList() {
+        return getDefaultDicList(Config.getCurrentLanguage());
+    }
+
+    public static ArrayList<File> getDefaultDicList(String language) {
+        final ArrayList<File> res = new ArrayList<File>();
+        final File userLanguageDir = new File(Config.getUserDir(), language);
+        File name2 = new File(userLanguageDir, "user_dic.def");
+        try {
+            final BufferedReader br = new BufferedReader(new FileReader(name2));
+            String s;
+            while ((s = br.readLine()) != null) {
+                res.add(new File(new File(userLanguageDir, "Dela"), s));
+            }
+            br.close();
+        } catch (final FileNotFoundException ee) {
+            // nothing to do
+        } catch (final IOException e) {
+            e.printStackTrace();
+        }
+        name2 = new File(userLanguageDir, "system_dic.def");
+        try {
+            final BufferedReader br = new BufferedReader(new FileReader(name2));
+            String s;
+            final File systemDelaDir = new File(new File(Config.getUnitexDir(),
+                    language), "Dela");
+            while ((s = br.readLine()) != null) {
+                res.add(new File(systemDelaDir, s));
+            }
+            br.close();
+        } catch (final FileNotFoundException ee) {
+            // nothing to do
+        } catch (final IOException e) {
+            // e.printStackTrace();
+        }
+        return res;
+    }
+
+    private static final ArrayList<LanguageListener> listeners = new ArrayList<LanguageListener>();
+    private static boolean firing = false;
+
+    public static void addLanguageListener(LanguageListener l) {
+        listeners.add(l);
+    }
+
+    public static void removeLanguageListener(LanguageListener l) {
+        if (firing) {
+            throw new IllegalStateException(
+                    "Should not remove a listener while firing");
+        }
+        listeners.remove(l);
+    }
+
+    private static void fireLanguageChanged() {
+        firing = true;
+        try {
+            for (final LanguageListener l : listeners) {
+                l.languageChanged();
+            }
+        } finally {
+            firing = false;
+        }
+    }
+
+    public static void cleanTfstFiles(boolean deleteSentenceGraphs) {
+        if (deleteSentenceGraphs) {
+            FileUtil.deleteFileByName(new File(Config.getCurrentSntDir(),
+                    "sentence*.grf"));
+        }
+        FileUtil.deleteFileByName(new File(Config.getCurrentSntDir(),
+                "cursentence.grf"));
+        FileUtil.deleteFileByName(new File(Config.getCurrentSntDir(),
+                "cursentence.txt"));
+        FileUtil.deleteFileByName(new File(Config.getCurrentSntDir(),
+                "currentelagsentence.grf"));
+        FileUtil.deleteFileByName(new File(Config.getCurrentSntDir(),
+                "currentelagsentence.txt"));
+        FileUtil.deleteFileByName(new File(Config.getCurrentSntDir(),
+                "text-elag.tfst"));
+        FileUtil.deleteFileByName(new File(Config.getCurrentSntDir(),
+                "text-elag.tfst.bak"));
+        FileUtil.deleteFileByName(new File(Config.getCurrentSntDir(),
+                "text-elag.tind"));
+        FileUtil.deleteFileByName(new File(Config.getCurrentSntDir(),
+                "text-elag.tind.bak"));
+        FileUtil.deleteFileByName(new File(Config.getCurrentSntDir(),
+                "tfst_tags_by_freq.txt"));
+        FileUtil.deleteFileByName(new File(Config.getCurrentSntDir(),
+                "tfst_tags_by_alph.txt"));
+    }
+
+    private static SvnMonitor monitor;
+
+    public static SvnMonitor getSvnMonitor() {
+        if (monitor == null) {
+            monitor = new SvnMonitor(null, true);
+        }
+        return monitor;
+    }
+    
+}

--- a/process/commands/AbstractCommand.java
+++ b/process/commands/AbstractCommand.java
@@ -1,0 +1,50 @@
+/*
+ * Unitex
+ *
+ * Copyright (C) 2001-2021 Université Paris-Est Marne-la-Vallée <unitex@univ-mlv.fr>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
+ *
+ */
+package fr.umlv.unitex.process.commands;
+
+import fr.umlv.unitex.console.ConsoleEntry;
+import fr.umlv.unitex.process.ExecParameters;
+import fr.umlv.unitex.process.ToDoAfterSingleCommand;
+import fr.umlv.unitex.process.ToDoBeforeSingleCommand;
+
+public interface AbstractCommand {
+
+	/**
+	 * Logs the command in Unitex's console
+	 */
+	public ConsoleEntry logIntoConsole();
+
+	/**
+	 * Executes the command and returns true iff the command successfully
+	 * executed
+	 */
+	public boolean executeCommand(final ExecParameters p,
+			final ConsoleEntry entry);
+
+	public void setWhatToDoBefore(ToDoBeforeSingleCommand r);
+
+	public ToDoBeforeSingleCommand getWhatToDoBefore();
+
+	public void setWhatToDoOnceCompleted(ToDoAfterSingleCommand r);
+
+	public ToDoAfterSingleCommand getWhatToDoOnceCompleted();
+
+}

--- a/process/commands/CommandBuilder.java
+++ b/process/commands/CommandBuilder.java
@@ -1,0 +1,319 @@
+/*
+ * Unitex
+ *
+ * Copyright (C) 2001-2021 Université Paris-Est Marne-la-Vallée <unitex@univ-mlv.fr>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
+ *
+ */
+package fr.umlv.unitex.process.commands;
+
+import java.io.File;
+import java.lang.reflect.InvocationTargetException;
+import java.util.ArrayList;
+
+import javax.swing.SwingUtilities;
+
+import fr.umlv.unitex.config.ConfigManager;
+import fr.umlv.unitex.console.Console;
+import fr.umlv.unitex.console.ConsoleEntry;
+import fr.umlv.unitex.console.Couple;
+import fr.umlv.unitex.process.EatStreamThread;
+import fr.umlv.unitex.process.ExecParameters;
+import fr.umlv.unitex.process.Log;
+import fr.umlv.unitex.process.ProcessInfoThread;
+import fr.umlv.unitex.process.ToDoAfterSingleCommand;
+import fr.umlv.unitex.process.ToDoBeforeSingleCommand;
+
+/**
+ * This class provides facilities for build process command lines.
+ * 
+ * @author Sébastien Paumier
+ */
+public abstract class CommandBuilder implements AbstractCommand {
+	public static final int PROGRAM = 0;
+	public static final int MESSAGE = 1;
+	public static final int ERROR_MESSAGE = 2;
+	public static final int METHOD = 3;
+	protected final ArrayList<String> list;
+	
+	/** 
+	 * Used for a very compact display in Gramlab's console
+	 */
+	protected final ArrayList<String> ultraSimplifiedList;
+	
+	int type = PROGRAM;
+	private boolean unitexProgram = true;
+	private int programNamePosition;
+
+	CommandBuilder(String programName) {
+		list = new ArrayList<String>();
+		ultraSimplifiedList = new ArrayList<String>();
+		protectElement(ConfigManager.getManager().getUnitexToolLogger()
+				.getAbsolutePath());
+		if (ConfigManager.getManager().mustLog(null)) {
+			element("{");
+			element("CreateLog");
+			element("-d");
+			protectElement(ConfigManager.getManager().getLogDirectory(null)
+					.getAbsolutePath());
+			element("-u");
+			element("}");
+		}
+		programNamePosition = list.size();
+		element(programName);
+		ultraSimplifiedList.add(programName);
+	}
+
+	public CommandBuilder() {
+		this(true);
+	}
+
+	public CommandBuilder(boolean unitexProgram) {
+		this.unitexProgram = unitexProgram;
+		list = new ArrayList<String>();
+		ultraSimplifiedList = new ArrayList<String>();
+	}
+
+	CommandBuilder(ArrayList<String> list) {
+		this.list = list;
+		this.ultraSimplifiedList = new ArrayList<String>();
+	}
+
+	public void element(String s) {
+		list.add(s);
+	}
+
+	public void element(char[] s) {
+		list.add(new String(s));
+	}
+
+	public void protectElement(String s) {
+		element("\"" + s + "\"");
+	}
+
+	public void protectElement(char[] s) {
+		element("\"" + new String(s) + "\"");
+	}
+
+	public String getOutputEncoding() {
+		if (!unitexProgram || getType() != PROGRAM) {
+			/* This is meaningful only for Unitex programs */
+			return null;
+		}
+		switch (ConfigManager.getManager().getEncoding(null)) {
+		case UTF8:
+			return "-qutf8-no-bom --locate_argument=--stack_max=8000 --locate_argument=--max_matches_per_subgraph=800 --locate_argument=--max_matches_at_token_pos=8000\r\n" + 
+					"";
+		case UTF16LE:
+			return null;
+		case UTF16BE:
+			return "-qutf16be-bom";
+		}
+		return null;
+	}
+
+	public void time(File f) {
+		list.add(programNamePosition, "\"--time=" + f.getAbsolutePath() + "\"");
+		programNamePosition++;
+	}
+
+	public String getCommandLine() {
+		String res = "";
+		for (final String aList : list) {
+			res = res + aList + " ";
+		}
+		if (getOutputEncoding() != null) {
+			res = res + getOutputEncoding();
+		}
+		return res;
+	}
+
+	public String getSimplifiedCommandLine() {
+		String res = "";
+		for (int i = programNamePosition; i < list.size(); i++) {
+			res = res + list.get(i) + " ";
+		}
+		if (getOutputEncoding() != null) {
+			res = res + getOutputEncoding();
+		}
+		return res;
+	}
+
+	public String getUltraSimplifiedCommandLine() {
+		String res = "";
+		for (final String s : ultraSimplifiedList) {
+			res = res + s + " ";
+		}
+		return res;
+	}
+
+	public String[] getCommandArguments() {
+		return getCommandArguments(true);
+	}
+
+	public String[] getCommandArguments(boolean setEncoding) {
+		String encoding = null;
+		if (setEncoding) {
+			encoding = getOutputEncoding();
+		}
+		final String[] res = list.toArray(new String[list.size()
+				+ ((encoding != null) ? 1 : 0)]);
+		for (int i = 0; i < list.size(); i++) {
+			if (res[i].startsWith("\"")) {
+				res[i] = res[i].substring(1, res[i].length() - 1);
+			}
+		}
+		if (encoding != null)
+			res[res.length - 1] = encoding;
+		return res;
+	}
+
+	public CommandBuilder getBuilder() {
+		return this;
+	}
+
+	@SuppressWarnings("unchecked")
+	ArrayList<String> getCopyOfList() {
+		return (ArrayList<String>) list.clone();
+	}
+
+	public int getType() {
+		return type;
+	}
+
+	@Override
+	public ConsoleEntry logIntoConsole() {
+		return Console.addCommand(getCommandLine(), false,
+				Log.getCurrentLogID());
+	}
+
+	/**
+	 * This is overridden by GrfDiffCommand
+	 */
+	public boolean isCommandSuccessful(int retValue) {
+		return retValue == 0;
+	}
+
+	/**
+	 * Executes the command, dealing with its outputs.
+	 */
+	@Override
+	public boolean executeCommand(final ExecParameters parameters,
+			final ConsoleEntry entry) {
+		Process p = null;
+		boolean problem = false;
+		final CommandBuilder currentCommand = this;
+		final String[] comm = getCommandArguments(true);
+		try {
+			/* We create the process */
+			parameters.setProcess(Runtime.getRuntime().exec(comm, null,
+					parameters.getWorkingDirectory()));
+			p = parameters.getProcess();
+			if (parameters.getStdout() == null) {
+				/* If needed, we just consume the output stream */
+				new EatStreamThread(p.getInputStream()).start();
+				entry.setNormalStreamEnded(true);
+			} else {
+				new ProcessInfoThread(parameters.getStdout(),
+						p.getInputStream(), entry, false).start();
+			}
+			if (parameters.getStderr() == null) {
+				/* If needed, we just consume the error stream */
+				new EatStreamThread(p.getErrorStream()).start();
+				entry.setErrorStreamEnded(true);
+			} else {
+				new ProcessInfoThread(parameters.getStderr(),
+						p.getErrorStream(), entry, true).start();
+			}
+			/* Now, we just wait for the end of the process */
+			try {
+				p.waitFor();
+				if (parameters.isStopOnProblem()) {
+					/* iff we need to report a problem */
+					if (!currentCommand.isCommandSuccessful(p.exitValue())) {
+						problem = true;
+					}
+				}
+				parameters.setProcess(null);
+				return !problem;
+			} catch (final java.lang.InterruptedException e) {
+				/*
+				 * If the process is interrupted for any reason, like a click on
+				 * a "Cancel" button
+				 */
+				if (parameters.isStopOnProblem()) {
+					try {
+						SwingUtilities.invokeAndWait(new Runnable() {
+							@Override
+							public void run() {
+								parameters.getStderr().addLine(
+										new Couple("The program " + comm[0]
+												+ " has been interrupted\n",
+												true));
+							}
+						});
+					} catch (final InterruptedException e1) {
+						e1.printStackTrace();
+					} catch (final InvocationTargetException e1) {
+						e1.printStackTrace();
+					}
+					problem = true;
+				}
+				parameters.setProcess(null);
+				return problem;
+			}
+		} catch (final java.io.IOException e) {
+			/* If the process could not be created */
+			final String programName = comm[0];
+			SwingUtilities.invokeLater(new Runnable() {
+				@Override
+				public void run() {
+					parameters.getStderr().addLine(
+							new Couple("Cannot launch the program "
+									+ programName + "\n", true));
+				}
+			});
+			if (parameters.isStopOnProblem()) {
+				problem = true;
+			}
+			parameters.setProcess(null);
+			return !problem;
+		}
+	}
+
+	private ToDoBeforeSingleCommand toDoBefore = null;
+	private ToDoAfterSingleCommand toDoAfter = null;
+
+	@Override
+	public void setWhatToDoBefore(ToDoBeforeSingleCommand r) {
+		this.toDoBefore = r;
+	}
+
+	@Override
+	public ToDoBeforeSingleCommand getWhatToDoBefore() {
+		return toDoBefore;
+	}
+
+	@Override
+	public void setWhatToDoOnceCompleted(ToDoAfterSingleCommand r) {
+		this.toDoAfter = r;
+	}
+
+	@Override
+	public ToDoAfterSingleCommand getWhatToDoOnceCompleted() {
+		return toDoAfter;
+	}
+}


### PR DESCRIPTION
## Description

Fixes 1 Change Cassys to solve the max stack size reached problem #

## Motivation and Context

Alexis Neme have a problem :
"When I execute Cassys  command (below) with IDE it generates the error "Max stack size reached" (attcahed file)
"Local\Unitex\App\UnitexToolLogger.exe" Cassys "-aUnitex3_2\English\Alphabet.txt" "-tUnitex3_2\English\Corpus\text.snt" "-lUnitex3_2\English\CasSys\cascade.csc" -v "-rUnitex3_2\English\Graphs\" "--input_offsets=Unitex3_2\English\Corpus\text_snt\normalize.out.offsets" -qutf8-no-bom

When I execute Cassys  command (below) with a command line, it does generate an error
"Local\Unitex\App\UnitexToolLogger.exe" Cassys "-aUnitex3_2\English\Alphabet.txt" "-tUnitex3_2\English\Corpus\text.snt" "-lUnitex3_2\English\CasSys\cascade.csc" -v "-rUnitex3_2\English\Graphs\" "--input_offsets=Unitex3_2\English\Corpus\text_snt\normalize.out.offsets" -qutf8-no-bom --locate_argument=--stack_max=8000 --locate_argument=--max_matches_per_subgraph=800 --locate_argument=--max_matches_at_token_pos=8000

I propose to include these parameters in bold to the Cassys command line call from the IDE"

## What I did

In gramlab-ide\unitex\src\fr\umlv\unitex\process\commands\CommandBuilder.java,
when we create the Cassys comand "-qutf8-no-bom", I add "-qutf8-no-bom --locate_argument=--stack_max=8000 --locate_argument=--max_matches_per_subgraph=800 --locate_argument=--max_matches_at_token_pos=8000"

Fixes 2 Preprocessing#

## Motivation and Context

When you lanch the Preprocessing, graph in MERGE mode and graph in REPLACE mode have the same path (Graphs\Preprocessing\Replace)

## What I did

In gramlab-ide\unitex\src\fr\umlv\unitex\frames\PreprocessDialog.java
Sentence and Replace used the same variable, I creat two different variables for having two different paths (Graphs\Preprocessing\Sentence and Graphs\Preprocessing\Replace).